### PR TITLE
Support 32-bit index buffers for glTF meshes

### DIFF
--- a/src/asset/mesh.rs
+++ b/src/asset/mesh.rs
@@ -5,13 +5,14 @@ pub struct Mesh {
     vertex_buffer: wgpu::Buffer,
     index_buffer: wgpu::Buffer,
     index_count: u32,
+    index_format: wgpu::IndexFormat,
 }
 
 impl Mesh {
     pub fn from_vertices(
         device: &wgpu::Device,
         vertices: &[crate::renderer::Vertex],
-        indices: &[u16],
+        indices: &[u32],
     ) -> Self {
         let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("VertexBuffer"),
@@ -29,6 +30,7 @@ impl Mesh {
             vertex_buffer,
             index_buffer,
             index_count: indices.len() as u32,
+            index_format: wgpu::IndexFormat::Uint32,
         }
     }
 
@@ -42,5 +44,9 @@ impl Mesh {
 
     pub fn index_count(&self) -> u32 {
         self.index_count
+    }
+
+    pub fn index_format(&self) -> wgpu::IndexFormat {
+        self.index_format
     }
 }

--- a/src/renderer/primitives.rs
+++ b/src/renderer/primitives.rs
@@ -1,6 +1,6 @@
 use super::vertex::{v, Vertex};
 
-pub fn cube_mesh() -> (Vec<Vertex>, Vec<u16>) {
+pub fn cube_mesh() -> (Vec<Vertex>, Vec<u32>) {
     let p = |x, y, z| [x, y, z];
     let verts = vec![
         v(p(0.5, -0.5, -0.5), [1.0, 0.0, 0.0], [0.0, 1.0]),
@@ -33,7 +33,7 @@ pub fn cube_mesh() -> (Vec<Vertex>, Vec<u16>) {
             let o = f * 4;
             [o, o + 1, o + 2, o, o + 2, o + 3]
         })
-        .map(|i| i as u16)
+        .map(|i| i as u32)
         .collect::<Vec<_>>();
     (verts, idx)
 }

--- a/src/renderer/renderer.rs
+++ b/src/renderer/renderer.rs
@@ -115,7 +115,7 @@ impl Renderer {
             .write_buffer(&self.camera_buffer.buffer, 0, bytemuck::bytes_of(&uni));
     }
 
-    pub fn create_mesh(&self, vertices: &[Vertex], indices: &[u16]) -> crate::asset::Mesh {
+    pub fn create_mesh(&self, vertices: &[Vertex], indices: &[u32]) -> crate::asset::Mesh {
         crate::asset::Mesh::from_vertices(&self.context.device, vertices, indices)
     }
 
@@ -239,7 +239,7 @@ impl Renderer {
 
                 let instance_count = instances.len() as u32;
                 rpass.set_vertex_buffer(0, mesh.vertex_buffer().slice(..));
-                rpass.set_index_buffer(mesh.index_buffer().slice(..), wgpu::IndexFormat::Uint16);
+                rpass.set_index_buffer(mesh.index_buffer().slice(..), mesh.index_format());
                 rpass.draw_indexed(
                     0..mesh.index_count(),
                     0,
@@ -254,7 +254,6 @@ impl Renderer {
         frame.present();
         Ok(())
     }
-
 }
 
 impl RenderContext {

--- a/src/scene/loader.rs
+++ b/src/scene/loader.rs
@@ -443,7 +443,6 @@ impl SceneLoader {
             .read_indices()
             .ok_or("Missing indices")?
             .into_u32()
-            .map(|i| i as u16)
             .collect::<Vec<_>>();
 
         log::trace!(


### PR DESCRIPTION
## Summary
- store the index format on Mesh and upload indices as u32 buffers
- switch renderer and primitive helpers to use 32-bit index data
- stop truncating glTF indices so large meshes render correctly

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e1787782a0832cbf9965f33bcd13a4