### PR TITLE
Use instant crate for wasm-safe timing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ bitflags = "2.4"
 image = "0.25"
 hecs = "0.10"
 gltf = "1.4"
+instant = { version = "0.1", features = ["wasm-bindgen"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,5 @@
 // app.rs - Complete fixed version with hierarchy test scene
+use instant::Instant;
 use winit::{
     application::ApplicationHandler,
     event::*,
@@ -727,7 +728,7 @@ impl ApplicationHandler for App {
                     false
                 };
 
-                let now = std::time::Instant::now();
+                let now = Instant::now();
                 let dt = (now - self.scene.last_frame()).as_secs_f64();
                 self.scene.set_last_frame(now);
 

--- a/src/scene/scene.rs
+++ b/src/scene/scene.rs
@@ -5,7 +5,7 @@ use crate::renderer::{RenderBatcher, RenderObject, Renderer};
 use crate::scene::Transform;
 use glam::{Quat, Vec3};
 use hecs::World;
-use std::time::Instant;
+use instant::Instant;
 
 pub struct Scene {
     pub world: World,


### PR DESCRIPTION
## Summary
- add the instant crate with the wasm-bindgen feature so native and wasm builds share the same timer implementation
- switch scene and app timing code to use instant::Instant for wasm compatibility

## Testing
- `./build_web.sh` *(fails: unable to reach crates.io index due to 403 CONNECT tunnel failure)*

------
https://chatgpt.com/codex/tasks/task_e_68e1a25d4f5c832c87c8bd99d54e6fde