### PR TITLE
Expose time module for wasm builds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod app;
 pub mod asset;
 pub mod renderer;
 pub mod scene;
+pub mod time;
 
 use app::{App, SceneType};
 use winit::event_loop::EventLoop;


### PR DESCRIPTION
## Summary
- re-export the crate's time module so consumers can import `Instant`

## Testing
- cargo check --target wasm32-unknown-unknown *(fails: unable to reach crates.io in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e1a5f2e51c832c956900b3b77d3b9f