### PR TITLE
Use crate Instant abstraction

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,4 @@
 // app.rs - Complete fixed version with hierarchy test scene
-use instant::Instant;
 use winit::{
     application::ApplicationHandler,
     event::*,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod app;
 pub mod asset;
 pub mod renderer;
 pub mod scene;
+pub mod time;
 
 use app::{App, SceneType};
 use winit::event_loop::EventLoop;

--- a/src/scene/scene.rs
+++ b/src/scene/scene.rs
@@ -6,7 +6,6 @@ use crate::scene::Transform;
 use crate::time::Instant;
 use glam::{Quat, Vec3};
 use hecs::World;
-use instant::Instant;
 
 pub struct Scene {
     pub world: World,


### PR DESCRIPTION
## Summary
- remove direct imports of the `instant` crate in `App` and `Scene`
- rely on the crate-local `Instant` wrapper so wasm builds resolve correctly

## Testing
- cargo check --target wasm32-unknown-unknown *(fails: unable to reach crates.io in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e1a5f2e51c832c956900b3b77d3b9f