### PR TITLE
Re-export Instant alias

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,4 @@
 // app.rs - Complete fixed version with hierarchy test scene
-use instant::Instant;
 use winit::{
     application::ApplicationHandler,
     event::*,
@@ -16,7 +15,7 @@ use crate::scene::{
     Camera, Children, EntityBuilder, MaterialComponent, MeshComponent, Name, OrbitAnimation,
     Parent, RotateAnimation, Scene, SceneLoader, Transform, TransformComponent, Visible,
 };
-use crate::time::Instant;
+use crate::Instant;
 use glam::{Quat, Vec3};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,9 @@ pub mod app;
 pub mod asset;
 pub mod renderer;
 pub mod scene;
+pub mod time;
+
+pub use time::Instant;
 
 use app::{App, SceneType};
 use winit::event_loop::EventLoop;

--- a/src/scene/scene.rs
+++ b/src/scene/scene.rs
@@ -3,10 +3,9 @@ use super::components::*;
 use crate::asset::Assets;
 use crate::renderer::{RenderBatcher, RenderObject, Renderer};
 use crate::scene::Transform;
-use crate::time::Instant;
+use crate::Instant;
 use glam::{Quat, Vec3};
 use hecs::World;
-use instant::Instant;
 
 pub struct Scene {
     pub world: World,


### PR DESCRIPTION
## Summary
- re-export the crate-local `Instant` wrapper from `lib.rs`
- update `App` and `Scene` to import the shared alias so builds resolve correctly

## Testing
- cargo check --target wasm32-unknown-unknown *(fails: unable to reach crates.io in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e1a5f2e51c832c956900b3b77d3b9f