### PR TITLE
Fix Instant imports for native builds

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -15,7 +15,7 @@ use crate::scene::{
     Camera, Children, EntityBuilder, MaterialComponent, MeshComponent, Name, OrbitAnimation,
     Parent, RotateAnimation, Scene, SceneLoader, Transform, TransformComponent, Visible,
 };
-use crate::Instant;
+use crate::time::Instant;
 use glam::{Quat, Vec3};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/scene/scene.rs
+++ b/src/scene/scene.rs
@@ -3,7 +3,7 @@ use super::components::*;
 use crate::asset::Assets;
 use crate::renderer::{RenderBatcher, RenderObject, Renderer};
 use crate::scene::Transform;
-use crate::Instant;
+use crate::time::Instant;
 use glam::{Quat, Vec3};
 use hecs::World;
 


### PR DESCRIPTION
## Summary
- update the app and scene modules to import `Instant` from the `time` module

## Testing
- cargo check *(fails: unable to download crates index due to 403 CONNECT tunnel error)*

------
https://chatgpt.com/codex/tasks/task_e_68e1aa41b9ec832c896f8ef8e574e3ab