### PR TITLE
Refine transform propagation

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -106,7 +106,7 @@ impl App {
             SceneType::MaterialShowcase => self.create_material_showcase(renderer),
             SceneType::HierarchyTest => self.create_hierarchy_test_scene(renderer),
             SceneType::FromGltf => {
-                if let Some(path) = &self.gltf_path.clone() {
+                if let Some(path) = self.gltf_path.as_deref() {
                     self.load_gltf_scene(path, renderer);
                 } else {
                     log::error!("No glTF path provided");


### PR DESCRIPTION
## Summary
- avoid cloning the stored glTF path when creating the FromGltf scene
- refactor transform propagation to reuse optional component queries and an iterative stack-based traversal
- add unit tests that cover rotation cases and updates to existing world transforms

## Testing
- `cargo test` *(fails: unable to download console_error_panic_hook due to 403 response)*

------
https://chatgpt.com/codex/tasks/task_e_68e252c627f4832c9e265e4642166012