### PR TITLE
Fix borrow checker violations in transform propagation and glTF loading

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -106,8 +106,8 @@ impl App {
             SceneType::MaterialShowcase => self.create_material_showcase(renderer),
             SceneType::HierarchyTest => self.create_hierarchy_test_scene(renderer),
             SceneType::FromGltf => {
-                if let Some(path) = self.gltf_path.as_deref() {
-                    self.load_gltf_scene(path, renderer);
+                if let Some(path) = self.gltf_path.clone() {
+                    self.load_gltf_scene(&path, renderer);
                 } else {
                     log::error!("No glTF path provided");
                     self.create_simple_scene(renderer);

--- a/src/scene/scene.rs
+++ b/src/scene/scene.rs
@@ -138,7 +138,7 @@ impl Scene {
         }
     }
 
-    fn system_orbit_animation(&mut self, dt: f64) {
+    fn system_orbit_animation(&mut self, _dt: f64) {
         let time = self.time as f32;
 
         for (_entity, (transform, orbit)) in self
@@ -200,21 +200,24 @@ impl Scene {
                     world.translation
                 );
 
-                match self.world.get::<&mut WorldTransform>(entity) {
-                    Ok(mut wt) => {
+                let mut has_world_transform = false;
+                {
+                    if let Ok(mut wt) = self.world.get::<&mut WorldTransform>(entity) {
                         wt.0 = world;
+                        has_world_transform = true;
                     }
-                    Err(_) => {
-                        if let Err(e) = self.world.insert_one(entity, WorldTransform(world)) {
-                            log::error!(
-                                "Failed to insert WorldTransform for entity {:?}: {:?}",
-                                entity,
-                                e
-                            );
-                            continue;
-                        } else {
-                            log::trace!("Inserted WorldTransform for entity {:?}", entity);
-                        }
+                }
+
+                if !has_world_transform {
+                    if let Err(e) = self.world.insert_one(entity, WorldTransform(world)) {
+                        log::error!(
+                            "Failed to insert WorldTransform for entity {:?}: {:?}",
+                            entity,
+                            e
+                        );
+                        continue;
+                    } else {
+                        log::trace!("Inserted WorldTransform for entity {:?}", entity);
                     }
                 }
 
@@ -233,7 +236,7 @@ impl Scene {
 
     pub fn debug_print_transforms(&self) {
         log::info!("=== Transform Debug ===");
-        for (entity, (name, local, world)) in self
+        for (_entity, (name, local, world)) in self
             .world
             .query::<(&Name, &TransformComponent, Option<&WorldTransform>)>()
             .iter()


### PR DESCRIPTION
## Summary
- avoid borrowing `App::gltf_path` immutably while loading scenes by cloning the stored path before calling the loader
- restructure transform propagation to drop immutable borrows before inserting new components and tidy unused variables

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68e257306344832c9898d112f6aa0760