### PR TITLE
Fix borrow conflicts in transform propagation tests

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -106,8 +106,8 @@ impl App {
             SceneType::MaterialShowcase => self.create_material_showcase(renderer),
             SceneType::HierarchyTest => self.create_hierarchy_test_scene(renderer),
             SceneType::FromGltf => {
-                if let Some(path) = self.gltf_path.as_deref() {
-                    self.load_gltf_scene(path, renderer);
+                if let Some(path) = self.gltf_path.clone() {
+                    self.load_gltf_scene(&path, renderer);
                 } else {
                     log::error!("No glTF path provided");
                     self.create_simple_scene(renderer);


### PR DESCRIPTION
## Summary
- release immutable world-transform borrows in transform propagation tests by scoping assertions in temporary blocks

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e257306344832c9898d112f6aa0760