### PR TITLE
Handle async renderer init on wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2988,6 +2988,7 @@ dependencies = [
  "log",
  "pollster",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-sys",
  "wgpu",
  "winit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ instant = { version = "0.1", features = ["wasm-bindgen"] }
 wasm-bindgen = "0.2"
 console_error_panic_hook = "0.1"
 console_log = "1.0"
+wasm-bindgen-futures = "0.4"
 web-sys = { version = "0.3", features = [
     "Document",
     "Window",


### PR DESCRIPTION
## Summary
- add wasm-bindgen-futures for the wasm32 build
- initialize the renderer asynchronously on wasm, deferring scene setup until the future completes
- guard event handling so pending initialization completes before rendering

## Testing
- `cargo check` *(fails: error downloading wgpu-hal due to 403 CONNECT tunnel response)*

------
https://chatgpt.com/codex/tasks/task_e_68e2753eb010832cb40c350bbda09ac9