### PR TITLE
Fix pending renderer borrowing in wasm async initialization

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -118,7 +118,7 @@ impl App {
             return;
         }
 
-        let Some(pending) = self.pending_renderer.as_ref() else {
+        let Some(pending) = self.pending_renderer.clone() else {
             return;
         };
 


### PR DESCRIPTION
## Summary
- clone the pending renderer handle before mutating self during async initialization
- allow the renderer setup to proceed without violating borrow rules on wasm

## Testing
- cargo check *(fails: unable to download crates due to 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e277c4faac832cb390e91c7c960bac