### PR TITLE
Fix pending renderer borrow lifetime on wasm initialization

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -122,7 +122,14 @@ impl App {
             return;
         };
 
-        if let Some(mut renderer) = pending.borrow_mut().take() {
+        let renderer_opt = {
+            let mut pending_ref = pending.borrow_mut();
+            pending_ref.take()
+        };
+
+        drop(pending);
+
+        if let Some(mut renderer) = renderer_opt {
             log::info!("Completing asynchronous renderer initialization");
 
             self.scene.init_timer();


### PR DESCRIPTION
## Summary
- avoid holding an active RefMut when finishing async renderer initialization
- drop the temporary borrow before consuming the pending renderer value

## Testing
- cargo check *(fails: network error downloading crates)*

------
https://chatgpt.com/codex/tasks/task_e_68e27847c738832ca226e406f895b5cd