### PR TITLE
Add WebGPU texture binding fallback

### DIFF
--- a/src/shader/bindings_bindless.wgsl
+++ b/src/shader/bindings_bindless.wgsl
@@ -1,0 +1,24 @@
+const MAX_TEXTURES: u32 = 256u;
+
+@group(2) @binding(0) var textures: binding_array<texture_2d<f32>, 256>;
+@group(2) @binding(1) var tex_sampler: sampler;
+
+fn sample_base_color_texture(index: u32, uv: vec2<f32>) -> vec4<f32> {
+    return textureSample(textures[index], tex_sampler, uv);
+}
+
+fn sample_metallic_roughness_texture(index: u32, uv: vec2<f32>) -> vec4<f32> {
+    return textureSample(textures[index], tex_sampler, uv);
+}
+
+fn sample_normal_texture(index: u32, uv: vec2<f32>) -> vec3<f32> {
+    return textureSample(textures[index], tex_sampler, uv).xyz;
+}
+
+fn sample_emissive_texture(index: u32, uv: vec2<f32>) -> vec3<f32> {
+    return textureSample(textures[index], tex_sampler, uv).rgb;
+}
+
+fn sample_occlusion_texture(index: u32, uv: vec2<f32>) -> f32 {
+    return textureSample(textures[index], tex_sampler, uv).r;
+}

--- a/src/shader/bindings_traditional.wgsl
+++ b/src/shader/bindings_traditional.wgsl
@@ -1,0 +1,26 @@
+@group(2) @binding(0) var base_color_texture_binding: texture_2d<f32>;
+@group(2) @binding(1) var metallic_roughness_texture_binding: texture_2d<f32>;
+@group(2) @binding(2) var normal_texture_binding: texture_2d<f32>;
+@group(2) @binding(3) var emissive_texture_binding: texture_2d<f32>;
+@group(2) @binding(4) var occlusion_texture_binding: texture_2d<f32>;
+@group(2) @binding(5) var tex_sampler: sampler;
+
+fn sample_base_color_texture(_index: u32, uv: vec2<f32>) -> vec4<f32> {
+    return textureSample(base_color_texture_binding, tex_sampler, uv);
+}
+
+fn sample_metallic_roughness_texture(_index: u32, uv: vec2<f32>) -> vec4<f32> {
+    return textureSample(metallic_roughness_texture_binding, tex_sampler, uv);
+}
+
+fn sample_normal_texture(_index: u32, uv: vec2<f32>) -> vec3<f32> {
+    return textureSample(normal_texture_binding, tex_sampler, uv).xyz;
+}
+
+fn sample_emissive_texture(_index: u32, uv: vec2<f32>) -> vec3<f32> {
+    return textureSample(emissive_texture_binding, tex_sampler, uv).rgb;
+}
+
+fn sample_occlusion_texture(_index: u32, uv: vec2<f32>) -> f32 {
+    return textureSample(occlusion_texture_binding, tex_sampler, uv).r;
+}


### PR DESCRIPTION
## Summary
- add a runtime texture binding strategy that selects bindless arrays when available and per-material bind groups otherwise
- bind traditional texture sets per material when adapters lack the bindless extension and reuse cached bind groups
- split shader bindings into reusable WGSL snippets so the fragment shader can target either binding model without changes

## Testing
- cargo check *(fails: unable to download crates due to 403 network error)*

------
https://chatgpt.com/codex/tasks/task_e_68e2797fa034832c979821aed9f82101