### PR TITLE
Fix web image loading for wasm builds

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -54,7 +54,11 @@ fn fetch_bytes_sync(url: &str) -> Result<Vec<u8>, String> {
 
     let buffer = request
         .response()
-        .ok_or_else(|| format!("No response body for {}", url))?;
+        .map_err(|err| format!("Failed to get response body for {}: {:?}", url, err))?;
+
+    if buffer.is_null() || buffer.is_undefined() {
+        return Err(format!("No response body for {}", url));
+    }
 
     let array = js_sys::Uint8Array::new(&buffer);
     let mut bytes = vec![0u8; array.length() as usize];


### PR DESCRIPTION
## Summary
- replace the use of the private `gltf::image::Data::new` helper with an open-coded conversion so the web target can compile
- improve WASM fetch error handling by mapping request.response errors and checking for missing bodies

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68e28487a4f8832c8588fb4f961ef454