### PR TITLE
Implement dynamic lighting buffers

### DIFF
--- a/src/renderer/lights.rs
+++ b/src/renderer/lights.rs
@@ -1,0 +1,195 @@
+use bytemuck::{Pod, Zeroable};
+use glam::Vec3;
+
+pub const MAX_DIRECTIONAL_LIGHTS: usize = 4;
+pub const MAX_POINT_LIGHTS: usize = 16;
+pub const MAX_SPOT_LIGHTS: usize = 8;
+
+#[derive(Clone, Copy, Debug)]
+pub struct DirectionalLightData {
+    pub direction: Vec3,
+    pub color: Vec3,
+    pub intensity: f32,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct PointLightData {
+    pub position: Vec3,
+    pub color: Vec3,
+    pub intensity: f32,
+    pub range: f32,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct SpotLightData {
+    pub position: Vec3,
+    pub direction: Vec3,
+    pub color: Vec3,
+    pub intensity: f32,
+    pub range: f32,
+    pub inner_angle: f32,
+    pub outer_angle: f32,
+}
+
+#[derive(Clone, Default)]
+pub struct LightsData {
+    directional: Vec<DirectionalLightData>,
+    point: Vec<PointLightData>,
+    spot: Vec<SpotLightData>,
+}
+
+impl LightsData {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn clear(&mut self) {
+        self.directional.clear();
+        self.point.clear();
+        self.spot.clear();
+    }
+
+    pub fn add_directional(&mut self, light: DirectionalLightData) {
+        self.directional.push(light);
+    }
+
+    pub fn add_point(&mut self, light: PointLightData) {
+        self.point.push(light);
+    }
+
+    pub fn add_spot(&mut self, light: SpotLightData) {
+        self.spot.push(light);
+    }
+
+    pub fn directional_lights(&self) -> &[DirectionalLightData] {
+        &self.directional
+    }
+
+    pub fn point_lights(&self) -> &[PointLightData] {
+        &self.point
+    }
+
+    pub fn spot_lights(&self) -> &[SpotLightData] {
+        &self.spot
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+pub struct DirectionalLightRaw {
+    pub direction: [f32; 4],
+    pub color_intensity: [f32; 4],
+}
+
+impl DirectionalLightRaw {
+    pub fn from_data(data: &DirectionalLightData) -> Self {
+        Self {
+            direction: [data.direction.x, data.direction.y, data.direction.z, 0.0],
+            color_intensity: [data.color.x, data.color.y, data.color.z, data.intensity],
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+pub struct PointLightRaw {
+    pub position_range: [f32; 4],
+    pub color_intensity: [f32; 4],
+}
+
+impl PointLightRaw {
+    pub fn from_data(data: &PointLightData) -> Self {
+        Self {
+            position_range: [
+                data.position.x,
+                data.position.y,
+                data.position.z,
+                data.range,
+            ],
+            color_intensity: [data.color.x, data.color.y, data.color.z, data.intensity],
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+pub struct SpotLightRaw {
+    pub position_range: [f32; 4],
+    pub direction: [f32; 4],
+    pub color_intensity: [f32; 4],
+    pub cone_params: [f32; 4],
+}
+
+impl SpotLightRaw {
+    pub fn from_data(data: &SpotLightData) -> Self {
+        let mut inner = data.inner_angle;
+        let mut outer = data.outer_angle;
+        if inner > outer {
+            std::mem::swap(&mut inner, &mut outer);
+        }
+        let cos_inner = inner.cos();
+        let cos_outer = outer.cos();
+
+        Self {
+            position_range: [
+                data.position.x,
+                data.position.y,
+                data.position.z,
+                data.range,
+            ],
+            direction: [data.direction.x, data.direction.y, data.direction.z, 0.0],
+            color_intensity: [data.color.x, data.color.y, data.color.z, data.intensity],
+            cone_params: [cos_inner, cos_outer, 0.0, 0.0],
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+pub struct LightsUniform {
+    pub counts: [u32; 4],
+    pub directionals: [DirectionalLightRaw; MAX_DIRECTIONAL_LIGHTS],
+    pub points: [PointLightRaw; MAX_POINT_LIGHTS],
+    pub spots: [SpotLightRaw; MAX_SPOT_LIGHTS],
+}
+
+impl LightsUniform {
+    pub fn from_data(data: &LightsData) -> Self {
+        let mut uniform = Self::zeroed();
+
+        let dir_count = data.directional_lights().len().min(MAX_DIRECTIONAL_LIGHTS) as u32;
+        uniform.counts[0] = dir_count;
+        for (dst, src) in uniform
+            .directionals
+            .iter_mut()
+            .zip(data.directional_lights().iter())
+            .take(dir_count as usize)
+        {
+            *dst = DirectionalLightRaw::from_data(src);
+        }
+
+        let point_count = data.point_lights().len().min(MAX_POINT_LIGHTS) as u32;
+        uniform.counts[1] = point_count;
+        for (dst, src) in uniform
+            .points
+            .iter_mut()
+            .zip(data.point_lights().iter())
+            .take(point_count as usize)
+        {
+            *dst = PointLightRaw::from_data(src);
+        }
+
+        let spot_count = data.spot_lights().len().min(MAX_SPOT_LIGHTS) as u32;
+        uniform.counts[2] = spot_count;
+        for (dst, src) in uniform
+            .spots
+            .iter_mut()
+            .zip(data.spot_lights().iter())
+            .take(spot_count as usize)
+        {
+            *dst = SpotLightRaw::from_data(src);
+        }
+
+        uniform
+    }
+}

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -1,19 +1,24 @@
 pub mod batch;
 pub mod depth;
+pub mod lights;
 pub mod material;
 pub mod objects;
 pub mod primitives;
-pub mod vertex;
-pub mod texture;
 pub mod renderer;
+pub mod texture;
 pub mod uniforms;
+pub mod vertex;
 
 pub use batch::{InstanceData, RenderBatcher, RenderObject};
 pub use depth::Depth;
+pub use lights::{
+    DirectionalLightData, LightsData, PointLightData, SpotLightData, MAX_DIRECTIONAL_LIGHTS,
+    MAX_POINT_LIGHTS, MAX_SPOT_LIGHTS,
+};
 pub use material::Material;
 pub use objects::ObjectData;
 pub use primitives::*;
-pub use vertex::Vertex;
-pub use texture::Texture;
 pub use renderer::Renderer;
+pub use texture::Texture;
 pub use uniforms::CameraUniform;
+pub use vertex::Vertex;

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -11,10 +11,7 @@ pub mod vertex;
 
 pub use batch::{InstanceData, RenderBatcher, RenderObject};
 pub use depth::Depth;
-pub use lights::{
-    DirectionalLightData, LightsData, PointLightData, SpotLightData, MAX_DIRECTIONAL_LIGHTS,
-    MAX_POINT_LIGHTS, MAX_SPOT_LIGHTS,
-};
+pub use lights::{LightsData, MAX_DIRECTIONAL_LIGHTS, MAX_POINT_LIGHTS, MAX_SPOT_LIGHTS};
 pub use material::Material;
 pub use objects::ObjectData;
 pub use primitives::*;

--- a/src/scene/scene.rs
+++ b/src/scene/scene.rs
@@ -1,10 +1,7 @@
 // scene/scene.rs - Fixed version with improved transform propagation
 use super::components::*;
 use crate::asset::Assets;
-use crate::renderer::{
-    DirectionalLightData, LightsData, PointLightData, RenderBatcher, RenderObject, Renderer,
-    SpotLightData,
-};
+use crate::renderer::{LightsData, RenderBatcher, RenderObject, Renderer};
 use crate::scene::Transform;
 use crate::time::Instant;
 use glam::{Quat, Vec3};
@@ -143,11 +140,7 @@ impl Scene {
                 Vec3::new(0.0, -1.0, 0.0)
             };
 
-            lights.add_directional(DirectionalLightData {
-                direction,
-                color: light.color,
-                intensity: light.intensity,
-            });
+            lights.add_directional(direction, light.color, light.intensity);
         }
 
         for (_entity, (light, world_transform, local_transform)) in self
@@ -164,12 +157,12 @@ impl Scene {
                 .or_else(|| local_transform.map(|t| t.0))
                 .unwrap_or(Transform::IDENTITY);
 
-            lights.add_point(PointLightData {
-                position: transform.translation,
-                color: light.color,
-                intensity: light.intensity,
-                range: light.range,
-            });
+            lights.add_point(
+                transform.translation,
+                light.color,
+                light.intensity,
+                light.range,
+            );
         }
 
         for (_entity, (light, world_transform, local_transform)) in self
@@ -192,15 +185,15 @@ impl Scene {
                 Vec3::new(0.0, -1.0, 0.0)
             };
 
-            lights.add_spot(SpotLightData {
-                position: transform.translation,
+            lights.add_spot(
+                transform.translation,
                 direction,
-                color: light.color,
-                intensity: light.intensity,
-                range: light.range,
-                inner_angle: light.inner_angle,
-                outer_angle: light.outer_angle,
-            });
+                light.color,
+                light.intensity,
+                light.range,
+                light.inner_angle,
+                light.outer_angle,
+            );
         }
 
         renderer.set_lights(&lights);

--- a/src/scene/scene.rs
+++ b/src/scene/scene.rs
@@ -1,7 +1,10 @@
 // scene/scene.rs - Fixed version with improved transform propagation
 use super::components::*;
 use crate::asset::Assets;
-use crate::renderer::{RenderBatcher, RenderObject, Renderer};
+use crate::renderer::{
+    DirectionalLightData, LightsData, PointLightData, RenderBatcher, RenderObject, Renderer,
+    SpotLightData,
+};
 use crate::scene::Transform;
 use crate::time::Instant;
 use glam::{Quat, Vec3};
@@ -118,6 +121,90 @@ impl Scene {
             );
         }
 
+        let mut lights = LightsData::default();
+
+        for (_entity, (light, world_transform, local_transform)) in self
+            .world
+            .query::<(
+                &DirectionalLight,
+                Option<&WorldTransform>,
+                Option<&TransformComponent>,
+            )>()
+            .iter()
+        {
+            let transform = world_transform
+                .map(|t| t.0)
+                .or_else(|| local_transform.map(|t| t.0))
+                .unwrap_or(Transform::IDENTITY);
+            let raw_dir = transform.rotation * Vec3::NEG_Z;
+            let direction = if raw_dir.length_squared() > 0.0 {
+                raw_dir.normalize()
+            } else {
+                Vec3::new(0.0, -1.0, 0.0)
+            };
+
+            lights.add_directional(DirectionalLightData {
+                direction,
+                color: light.color,
+                intensity: light.intensity,
+            });
+        }
+
+        for (_entity, (light, world_transform, local_transform)) in self
+            .world
+            .query::<(
+                &PointLight,
+                Option<&WorldTransform>,
+                Option<&TransformComponent>,
+            )>()
+            .iter()
+        {
+            let transform = world_transform
+                .map(|t| t.0)
+                .or_else(|| local_transform.map(|t| t.0))
+                .unwrap_or(Transform::IDENTITY);
+
+            lights.add_point(PointLightData {
+                position: transform.translation,
+                color: light.color,
+                intensity: light.intensity,
+                range: light.range,
+            });
+        }
+
+        for (_entity, (light, world_transform, local_transform)) in self
+            .world
+            .query::<(
+                &SpotLight,
+                Option<&WorldTransform>,
+                Option<&TransformComponent>,
+            )>()
+            .iter()
+        {
+            let transform = world_transform
+                .map(|t| t.0)
+                .or_else(|| local_transform.map(|t| t.0))
+                .unwrap_or(Transform::IDENTITY);
+            let raw_dir = transform.rotation * Vec3::NEG_Z;
+            let direction = if raw_dir.length_squared() > 0.0 {
+                raw_dir.normalize()
+            } else {
+                Vec3::new(0.0, -1.0, 0.0)
+            };
+
+            lights.add_spot(SpotLightData {
+                position: transform.translation,
+                direction,
+                color: light.color,
+                intensity: light.intensity,
+                range: light.range,
+                inner_angle: light.inner_angle,
+                outer_angle: light.outer_angle,
+            });
+        }
+
+        renderer.set_lights(&lights);
+
         if let Err(e) = renderer.render(&self.assets, batcher) {
             log::error!("Render error: {:?}", e);
         }
@@ -230,9 +317,7 @@ impl Scene {
         }
     }
 
-
-    
-// ========================================================================
+    // ========================================================================
     // Scene Composition
     // ========================================================================
 
@@ -246,12 +331,16 @@ impl Scene {
 
         // First pass: spawn all entities and build the mapping
         // Collect all entity IDs first (query with no filter gets all entities)
-        let entities_to_copy: Vec<_> = other.world.iter().map(|entity_ref| entity_ref.entity()).collect();
-        
+        let entities_to_copy: Vec<_> = other
+            .world
+            .iter()
+            .map(|entity_ref| entity_ref.entity())
+            .collect();
+
         for old_entity in entities_to_copy {
             // Build a new entity with the same components (except Parent/Children for now)
             let mut builder = hecs::EntityBuilder::new();
-            
+
             // Copy all components except Parent and Children
             // Clone components to avoid holding borrows
             if let Ok(name) = other.world.get::<&Name>(old_entity) {
@@ -285,11 +374,14 @@ impl Scene {
         }
 
         // Second pass: fix up Parent and Children references
-        let parent_children_to_fix: Vec<_> = entity_map.iter().map(|(old, new)| {
-            let parent = other.world.get::<&Parent>(*old).ok().map(|p| p.0);
-            let children = other.world.get::<&Children>(*old).ok().map(|c| c.0.clone());
-            (*old, *new, parent, children)
-        }).collect();
+        let parent_children_to_fix: Vec<_> = entity_map
+            .iter()
+            .map(|(old, new)| {
+                let parent = other.world.get::<&Parent>(*old).ok().map(|p| p.0);
+                let children = other.world.get::<&Children>(*old).ok().map(|c| c.0.clone());
+                (*old, *new, parent, children)
+            })
+            .collect();
 
         // Find root entities (those without Parent in the original scene)
         let mut root_entities = Vec::new();
@@ -311,20 +403,26 @@ impl Scene {
 
             // Update Children component
             if let Some(old_children) = children {
-                let new_children: Vec<_> = old_children.iter()
+                let new_children: Vec<_> = old_children
+                    .iter()
                     .filter_map(|old_child| entity_map.get(old_child).copied())
                     .collect();
-                
+
                 if !new_children.is_empty() {
-                    self.world.insert_one(new_entity, Children(new_children)).ok();
+                    self.world
+                        .insert_one(new_entity, Children(new_children))
+                        .ok();
                 }
             }
         }
 
         // Make all root entities children of the specified parent
         if !root_entities.is_empty() {
-            log::info!("Setting {} root entities as children of parent", root_entities.len());
-            
+            log::info!(
+                "Setting {} root entities as children of parent",
+                root_entities.len()
+            );
+
             // Set parent reference on all roots
             for &root in &root_entities {
                 self.world.insert_one(root, Parent(parent_entity)).ok();
@@ -333,7 +431,7 @@ impl Scene {
             // Add roots to parent's children list
             // Check if parent already has children
             let has_children = self.world.get::<&Children>(parent_entity).is_ok();
-            
+
             if has_children {
                 // Parent has children, extend the list
                 if let Ok(mut parent_children) = self.world.get::<&mut Children>(parent_entity) {
@@ -341,16 +439,20 @@ impl Scene {
                 }
             } else {
                 // Parent didn't have children, create new list
-                self.world.insert_one(parent_entity, Children(root_entities)).ok();
+                self.world
+                    .insert_one(parent_entity, Children(root_entities))
+                    .ok();
             }
         }
 
         // Merge assets
         // Note: This just adds new assets, doesn't remap handles
         // If you need handle remapping, you'd need to track asset handles during copy
-        log::info!("Merged {} meshes, {} textures", 
-            other.assets.meshes.len(), 
-            other.assets.textures.len());
+        log::info!(
+            "Merged {} meshes, {} textures",
+            other.assets.meshes.len(),
+            other.assets.textures.len()
+        );
     }
 
     // ========================================================================

--- a/src/shader/bindings_bindless.wgsl
+++ b/src/shader/bindings_bindless.wgsl
@@ -1,7 +1,7 @@
 const MAX_TEXTURES: u32 = 256u;
 
-@group(2) @binding(0) var textures: binding_array<texture_2d<f32>, 256>;
-@group(2) @binding(1) var tex_sampler: sampler;
+@group(3) @binding(0) var textures: binding_array<texture_2d<f32>, 256>;
+@group(3) @binding(1) var tex_sampler: sampler;
 
 fn sample_base_color_texture(index: u32, uv: vec2<f32>) -> vec4<f32> {
     return textureSample(textures[index], tex_sampler, uv);

--- a/src/shader/bindings_traditional.wgsl
+++ b/src/shader/bindings_traditional.wgsl
@@ -1,9 +1,9 @@
-@group(2) @binding(0) var base_color_texture_binding: texture_2d<f32>;
-@group(2) @binding(1) var metallic_roughness_texture_binding: texture_2d<f32>;
-@group(2) @binding(2) var normal_texture_binding: texture_2d<f32>;
-@group(2) @binding(3) var emissive_texture_binding: texture_2d<f32>;
-@group(2) @binding(4) var occlusion_texture_binding: texture_2d<f32>;
-@group(2) @binding(5) var tex_sampler: sampler;
+@group(3) @binding(0) var base_color_texture_binding: texture_2d<f32>;
+@group(3) @binding(1) var metallic_roughness_texture_binding: texture_2d<f32>;
+@group(3) @binding(2) var normal_texture_binding: texture_2d<f32>;
+@group(3) @binding(3) var emissive_texture_binding: texture_2d<f32>;
+@group(3) @binding(4) var occlusion_texture_binding: texture_2d<f32>;
+@group(3) @binding(5) var tex_sampler: sampler;
 
 fn sample_base_color_texture(_index: u32, uv: vec2<f32>) -> vec4<f32> {
     return textureSample(base_color_texture_binding, tex_sampler, uv);


### PR DESCRIPTION
## Summary
- add GPU light data structures and conversion helpers for ECS lighting
- upload light data via a dedicated renderer storage buffer and bind it in the pipeline
- gather light components during scene rendering and consume them in the shader instead of hardcoded lights

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68e2b31a4504832cb2c4cc3344d36764