### PR TITLE
Add default component-based lighting to scenes

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -168,6 +168,11 @@ impl App {
             _ => {}
         }
 
+        let added_lights = self.scene.add_default_lighting();
+        if added_lights > 0 {
+            log::info!("Added {} default lights to scene", added_lights);
+        }
+
         // CRITICAL: Propagate transforms immediately after scene creation
         // This ensures WorldTransform components exist before first render
         log::info!("Running initial transform propagation...");


### PR DESCRIPTION
## Summary
- add a scene helper that spawns a trio of component-based default lights when a scene lacks lighting
- call the helper from `App::setup_scene` so every scene gets consistent default illumination

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68e2baaf8d58832c9793ecebb91d5563