### PR TITLE
Improve PBR test scene material setup

### DIFF
--- a/src/renderer/texture.rs
+++ b/src/renderer/texture.rs
@@ -386,6 +386,25 @@ impl Texture {
         Self::from_color(device, queue, [255, 255, 255, 255], Some("White"))
     }
 
+    /// Create a solid-color texture stored in a linear color space (1x1)
+    pub fn from_color_linear(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        color: [u8; 4],
+        label: Option<&str>,
+    ) -> Self {
+        Self::from_rgba8(
+            device,
+            queue,
+            &color,
+            1,
+            1,
+            wgpu::TextureFormat::Rgba8Unorm,
+            label,
+        )
+        .unwrap()
+    }
+
     /// Create default normal map (1x1, pointing up)
     pub fn default_normal(device: &wgpu::Device, queue: &wgpu::Queue) -> Self {
         // Normal pointing straight up: (0, 0, 1) -> (128, 128, 255) in texture space


### PR DESCRIPTION
## Summary
- add a linear 1x1 metallic-roughness texture and apply it when building the PBR test spheres so the shader follows the textured code path
- update axis label textures in the PBR scene to use the actual texture handles and avoid hard-coded indices
- extend the texture utilities with a `from_color_linear` helper and add unit tests covering constant PBR material factors

## Testing
- `cargo test object_data_pbr_factors`


------
https://chatgpt.com/codex/tasks/task_e_68e2be6567d0832c9021ea3f5c166942