### PR TITLE
Add shadow map support for configurable light casters

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -11,7 +11,10 @@ pub mod vertex;
 
 pub use batch::{InstanceData, RenderBatcher, RenderObject};
 pub use depth::Depth;
-pub use lights::{LightsData, MAX_DIRECTIONAL_LIGHTS, MAX_POINT_LIGHTS, MAX_SPOT_LIGHTS};
+pub use lights::{
+    DirectionalShadowData, LightsData, PointShadowData, SpotShadowData, MAX_DIRECTIONAL_LIGHTS,
+    MAX_POINT_LIGHTS, MAX_SPOT_LIGHTS,
+};
 pub use material::Material;
 pub use objects::ObjectData;
 pub use primitives::*;

--- a/src/scene/components.rs
+++ b/src/scene/components.rs
@@ -66,6 +66,16 @@ pub struct SpotLight {
     pub range: f32,
 }
 
+/// Marker/flag component indicating a light should cast shadows
+#[derive(Debug, Clone, Copy)]
+pub struct CanCastShadow(pub bool);
+
+impl Default for CanCastShadow {
+    fn default() -> Self {
+        Self(true)
+    }
+}
+
 // ============================================================================
 // Utility Components
 // ============================================================================

--- a/src/shader/shadow.wgsl
+++ b/src/shader/shadow.wgsl
@@ -1,0 +1,36 @@
+struct ShadowGlobals {
+    view_proj: mat4x4<f32>;
+};
+@group(0) @binding(0) var<uniform> shadow_globals: ShadowGlobals;
+
+struct Object {
+    model: mat4x4<f32>,
+    color: vec4<f32>,
+    base_color_texture: u32,
+    metallic_roughness_texture: u32,
+    normal_texture: u32,
+    emissive_texture: u32,
+    occlusion_texture: u32,
+    material_flags: u32,
+    metallic_factor: f32,
+    roughness_factor: f32,
+    emissive_strength: f32,
+    _padding: u32,
+    _padding2: vec2<u32>,
+};
+@group(1) @binding(0) var<storage, read> objects: array<Object>;
+
+struct VsIn {
+    @location(0) pos: vec3<f32>,
+    @location(1) normal: vec3<f32>,
+    @location(2) uv: vec2<f32>,
+    @location(3) tangent: vec4<f32>,
+    @builtin(instance_index) instance: u32,
+};
+
+@vertex
+fn vs_main(in: VsIn) -> @builtin(position) vec4<f32> {
+    let obj = objects[in.instance];
+    let world = obj.model * vec4<f32>(in.pos, 1.0);
+    return shadow_globals.view_proj * world;
+}


### PR DESCRIPTION
## Summary
- Add a `CanCastShadow` marker and extend the scene systems to build shadow view-projection data for directional, point, and spot lights
- Expand the renderer with dedicated shadow map resources, rendering passes, and a WGSL shadow vertex shader while wiring the bind group layout into the main pipeline
- Update lighting uniforms and the fragment shader to sample depth textures for per-light shadows, enabling shadows on the default lighting setup

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68e2c71a0cfc832c83a1d5a48d31b422