### PR TITLE
Increase device bind group limit for shadow maps

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -23,8 +23,8 @@ type WindowHandle = Window;
 type PendingRenderer = Rc<RefCell<Option<Renderer>>>;
 
 use crate::scene::{
-    Camera, Children, EntityBuilder, MaterialComponent, MeshComponent, Name,
-    Parent, RotateAnimation, Scene, SceneLoader, Transform, TransformComponent, Visible,
+    Camera, Children, EntityBuilder, MaterialComponent, MeshComponent, Name, Parent,
+    RotateAnimation, Scene, SceneLoader, Transform, TransformComponent, Visible,
 };
 use crate::time::Instant;
 use glam::{Quat, Vec3};

--- a/src/renderer/renderer.rs
+++ b/src/renderer/renderer.rs
@@ -366,7 +366,7 @@ impl RenderContext {
         };
 
         // Only set special limits if using bindless
-        let limits = if supports_bindless_textures {
+        let mut limits = if supports_bindless_textures {
             wgpu::Limits {
                 max_binding_array_elements_per_shader_stage: 256,
                 ..wgpu::Limits::default()
@@ -374,6 +374,13 @@ impl RenderContext {
         } else {
             wgpu::Limits::default()
         };
+
+        // Shadow mapping introduces an additional bind group, so ensure we request
+        // enough bind groups from the adapter. The default limit is 4, which now
+        // overflows at runtime when the shader expects group 4. Requesting a
+        // slightly higher limit keeps compatibility with existing defaults while
+        // avoiding validation errors on adapters that support more bind groups.
+        limits.max_bind_groups = limits.max_bind_groups.max(5);
 
         let (device, queue) = adapter
             .request_device(&wgpu::DeviceDescriptor {


### PR DESCRIPTION
## Summary
- request at least five bind groups from the adapter so the shadow sampling bind group no longer exceeds the limit
- run rustfmt, which reordered a use list in `app.rs`

## Testing
- cargo fmt
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68e2cbeb3a5c832cb38fc940f50b17c9