### PR TITLE
Use main.rs as wasm entry point

### DIFF
--- a/build_web.sh
+++ b/build_web.sh
@@ -1,2 +1,12 @@
-RUSTFLAGS="--cfg=web_sys_unstable_apis" cargo build --lib --target wasm32-unknown-unknown --release && wasm-bindgen --target web --out-dir web/pkg target/wasm32-unknown-unknown/release/wgpu_cube.wasm
+#!/usr/bin/env bash
+set -euo pipefail
+
+RUSTFLAGS="--cfg=web_sys_unstable_apis" \
+    cargo build --target wasm32-unknown-unknown --release --bin wgpu-cube
+
+wasm-bindgen \
+    --target web \
+    --out-dir web/pkg \
+    target/wasm32-unknown-unknown/release/wgpu-cube.wasm
+
 python3 -m http.server --directory web 8080

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,9 +67,3 @@ pub fn run_with_app(app: App) -> Result<(), JsValue> {
 
     Ok(())
 }
-
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen(start)]
-pub fn start() -> Result<(), JsValue> {
-    run(AppBuilder::default())
-}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,9 @@ mod demo_scenes;
 use demo_scenes::DemoScene;
 use wgpu_cube::AppBuilder;
 
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+
 //const ACTIVE_SCENE: DemoScene = DemoScene::ShadowTest;
 
 const ACTIVE_SCENE: DemoScene = DemoScene::Gltf {
@@ -10,11 +13,21 @@ const ACTIVE_SCENE: DemoScene = DemoScene::Gltf {
     scale: 15.0,
 };
 
-fn main() {
+fn build_app() -> AppBuilder {
     let mut builder = AppBuilder::new();
     builder.add_plugin(ACTIVE_SCENE.plugin());
+    builder
+}
 
-    if let Err(err) = wgpu_cube::run(builder) {
+#[cfg(not(target_arch = "wasm32"))]
+fn main() {
+    if let Err(err) = wgpu_cube::run(build_app()) {
         eprintln!("Application error: {err}");
     }
+}
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen(start)]
+pub fn main() -> Result<(), JsValue> {
+    wgpu_cube::run(build_app())
 }


### PR DESCRIPTION
## Summary
- share app construction in `main.rs` and use the binary as the wasm entry point via `wasm_bindgen(start)`
- update the web build script to compile the binary target and process the resulting wasm output
- remove the legacy wasm `start` shim from the library to avoid duplicate entry points

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68e417dde5c4832cb95398ffdff56d09