### PR TITLE
Fix wasm entry point naming conflict

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,6 @@ fn main() {
 
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen(start)]
-pub fn main() -> Result<(), JsValue> {
+pub fn start() -> Result<(), JsValue> {
     wgpu_cube::run(build_app())
 }


### PR DESCRIPTION
## Summary
- rename the wasm32 entry point to `start` to avoid conflicting `main` symbols when building for the web

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68e41d0fb998832cb5c46ba142efdb82