### PR TITLE
Add SSAO and bloom postprocessing pipeline

### DIFF
--- a/src/renderer/depth.rs
+++ b/src/renderer/depth.rs
@@ -4,11 +4,12 @@ pub struct Depth {
     pub texture: wgpu::Texture, // keep the texture alive
     pub view: wgpu::TextureView,
     pub format: wgpu::TextureFormat,
+    pub sampled_view: wgpu::TextureView,
 }
 
 impl Depth {
     pub fn new(device: &wgpu::Device, size: PhysicalSize<u32>, sample_count: u32) -> Self {
-        let format = wgpu::TextureFormat::Depth24Plus; // keep your chosen format
+        let format = wgpu::TextureFormat::Depth32Float;
         let texture = device.create_texture(&wgpu::TextureDescriptor {
             label: Some("Depth"),
             size: wgpu::Extent3d {
@@ -20,15 +21,21 @@ impl Depth {
             sample_count, // <- match MSAA sample count (e.g., 4)
             dimension: wgpu::TextureDimension::D2,
             format,
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
             view_formats: &[],
         });
 
         let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let sampled_view = texture.create_view(&wgpu::TextureViewDescriptor {
+            label: Some("DepthSampledView"),
+            aspect: wgpu::TextureAspect::DepthOnly,
+            ..Default::default()
+        });
         Self {
             texture,
             view,
             format,
+            sampled_view,
         }
     }
 }
@@ -36,8 +43,8 @@ impl Depth {
 #[cfg(test)]
 mod tests {
     #[test]
-    fn depth_format_is_depth24plus() {
-        let fmt = wgpu::TextureFormat::Depth24Plus;
-        assert!(matches!(fmt, wgpu::TextureFormat::Depth24Plus));
+    fn depth_format_is_depth32float() {
+        let fmt = wgpu::TextureFormat::Depth32Float;
+        assert!(matches!(fmt, wgpu::TextureFormat::Depth32Float));
     }
 }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -3,6 +3,7 @@ pub mod depth;
 pub mod lights;
 pub mod material;
 pub mod objects;
+pub mod postprocess;
 pub mod primitives;
 pub mod renderer;
 pub mod texture;

--- a/src/renderer/postprocess/mod.rs
+++ b/src/renderer/postprocess/mod.rs
@@ -1,0 +1,833 @@
+use bytemuck::{Pod, Zeroable};
+use glam::Mat4;
+
+const NOISE_TEXTURE_SIZE: u32 = 4;
+const SSAO_NOISE_DATA: [f32; (NOISE_TEXTURE_SIZE * NOISE_TEXTURE_SIZE * 4) as usize] = [
+    0.5381, 0.1856, 0.0, 0.0, 0.1379, 0.2486, 0.0, 0.0, 0.3371, 0.5679, 0.0, 0.0, -0.6999, -0.0451,
+    0.0, 0.0, 0.0689, -0.1598, 0.0, 0.0, 0.0560, 0.0069, 0.0, 0.0, -0.0146, 0.1402, 0.0, 0.0,
+    0.0100, -0.1924, 0.0, 0.0, -0.3577, -0.5301, 0.0, 0.0, -0.3169, 0.1063, 0.0, 0.0, 0.0103,
+    -0.5869, 0.0, 0.0, -0.0897, -0.4940, 0.0, 0.0, 0.7119, -0.0154, 0.0, 0.0, -0.0533, 0.0596, 0.0,
+    0.0, 0.0352, -0.0631, 0.0, 0.0, -0.4776, 0.2847, 0.0, 0.0,
+];
+
+pub struct PostProcess {
+    scene: TextureBundle,
+    ssao: TextureBundle,
+    bloom_ping: TextureBundle,
+    bloom_pong: TextureBundle,
+    sampler_linear: wgpu::Sampler,
+    sampler_clamp: wgpu::Sampler,
+    _noise_texture: wgpu::Texture,
+    noise_view: wgpu::TextureView,
+    uniform_buffer: wgpu::Buffer,
+    uniform_bind_group: wgpu::BindGroup,
+    ssao_layout: wgpu::BindGroupLayout,
+    ssao_pipeline: wgpu::RenderPipeline,
+    bloom_prefilter_layout: wgpu::BindGroupLayout,
+    bloom_prefilter_pipeline: wgpu::RenderPipeline,
+    bloom_blur_layout: wgpu::BindGroupLayout,
+    bloom_blur_horizontal: wgpu::RenderPipeline,
+    bloom_blur_vertical: wgpu::RenderPipeline,
+    composite_layout: wgpu::BindGroupLayout,
+    composite_pipeline: wgpu::RenderPipeline,
+    size: wgpu::Extent3d,
+    last_proj: Mat4,
+    last_near: f32,
+    last_far: f32,
+}
+
+impl PostProcess {
+    pub fn new(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        config: &wgpu::SurfaceConfiguration,
+    ) -> Self {
+        let size = wgpu::Extent3d {
+            width: config.width.max(1),
+            height: config.height.max(1),
+            depth_or_array_layers: 1,
+        };
+
+        let sampler_linear = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("PostProcessLinearSampler"),
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            mipmap_filter: wgpu::FilterMode::Linear,
+            ..Default::default()
+        });
+
+        let sampler_clamp = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("PostProcessClampSampler"),
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            mipmap_filter: wgpu::FilterMode::Linear,
+            ..Default::default()
+        });
+
+        let scene = TextureBundle::color(device, &size, config.format, "SceneColor");
+        let ssao = TextureBundle::ssao(device, &size);
+        let bloom_ping = TextureBundle::bloom(device, &size, "BloomPing");
+        let bloom_pong = TextureBundle::bloom(device, &size, "BloomPong");
+
+        let uniform_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("PostProcessUniformLayout"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: Some(
+                        wgpu::BufferSize::new(std::mem::size_of::<PostProcessUniform>() as u64)
+                            .expect("post process uniform must have non-zero size"),
+                    ),
+                },
+                count: None,
+            }],
+        });
+
+        let uniform_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("PostProcessUniformBuffer"),
+            size: std::mem::size_of::<PostProcessUniform>() as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let uniform_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("PostProcessUniformBindGroup"),
+            layout: &uniform_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: uniform_buffer.as_entire_binding(),
+            }],
+        });
+
+        let noise_texture = Self::create_noise_texture(device, queue);
+        let noise_view = noise_texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+        let postprocess_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("PostProcessShader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("../../shader/postprocess.wgsl").into()),
+        });
+
+        let fullscreen_vertex = wgpu::VertexState {
+            module: &postprocess_shader,
+            entry_point: Some("vs_fullscreen"),
+            buffers: &[],
+            compilation_options: Default::default(),
+        };
+
+        // SSAO pipeline setup
+        let ssao_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("SsaoInputLayout"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Depth,
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+            ],
+        });
+
+        let ssao_pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("SsaoPipelineLayout"),
+            bind_group_layouts: &[&uniform_layout, &ssao_layout],
+            push_constant_ranges: &[],
+        });
+
+        let ssao_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("SsaoPipeline"),
+            layout: Some(&ssao_pipeline_layout),
+            vertex: fullscreen_vertex.clone(),
+            fragment: Some(wgpu::FragmentState {
+                module: &postprocess_shader,
+                entry_point: Some("fs_ssao"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: wgpu::TextureFormat::R8Unorm,
+                    blend: None,
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+
+        // Bloom prefilter pipeline
+        let bloom_prefilter_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("BloomPrefilterLayout"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            multisampled: false,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                ],
+            });
+
+        let bloom_prefilter_pipeline_layout =
+            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("BloomPrefilterPipelineLayout"),
+                bind_group_layouts: &[&bloom_prefilter_layout],
+                push_constant_ranges: &[],
+            });
+
+        let bloom_prefilter_pipeline =
+            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("BloomPrefilterPipeline"),
+                layout: Some(&bloom_prefilter_pipeline_layout),
+                vertex: fullscreen_vertex.clone(),
+                fragment: Some(wgpu::FragmentState {
+                    module: &postprocess_shader,
+                    entry_point: Some("fs_bloom_prefilter"),
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format: bloom_ping.format,
+                        blend: Some(wgpu::BlendState::REPLACE),
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                    compilation_options: Default::default(),
+                }),
+                primitive: wgpu::PrimitiveState::default(),
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState::default(),
+                multiview: None,
+                cache: None,
+            });
+
+        // Bloom blur pipeline (horizontal & vertical)
+        let bloom_blur_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("BloomBlurLayout"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+            ],
+        });
+
+        let bloom_blur_pipeline_layout =
+            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("BloomBlurPipelineLayout"),
+                bind_group_layouts: &[&bloom_blur_layout],
+                push_constant_ranges: &[],
+            });
+
+        let bloom_blur_horizontal =
+            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("BloomBlurHorizontal"),
+                layout: Some(&bloom_blur_pipeline_layout),
+                vertex: fullscreen_vertex.clone(),
+                fragment: Some(wgpu::FragmentState {
+                    module: &postprocess_shader,
+                    entry_point: Some("fs_bloom_blur_horizontal"),
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format: bloom_pong.format,
+                        blend: Some(wgpu::BlendState::REPLACE),
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                    compilation_options: Default::default(),
+                }),
+                primitive: wgpu::PrimitiveState::default(),
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState::default(),
+                multiview: None,
+                cache: None,
+            });
+
+        let bloom_blur_vertical = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("BloomBlurVertical"),
+            layout: Some(&bloom_blur_pipeline_layout),
+            vertex: fullscreen_vertex.clone(),
+            fragment: Some(wgpu::FragmentState {
+                module: &postprocess_shader,
+                entry_point: Some("fs_bloom_blur_vertical"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: bloom_ping.format,
+                    blend: Some(wgpu::BlendState::REPLACE),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+
+        // Composite pipeline
+        let composite_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("CompositeLayout"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 3,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+            ],
+        });
+
+        let composite_pipeline_layout =
+            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("CompositePipelineLayout"),
+                bind_group_layouts: &[&composite_layout, &uniform_layout],
+                push_constant_ranges: &[],
+            });
+
+        let composite_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("CompositePipeline"),
+            layout: Some(&composite_pipeline_layout),
+            vertex: fullscreen_vertex,
+            fragment: Some(wgpu::FragmentState {
+                module: &postprocess_shader,
+                entry_point: Some("fs_composite"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: config.format,
+                    blend: Some(wgpu::BlendState::REPLACE),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+
+        let post = Self {
+            scene,
+            ssao,
+            bloom_ping,
+            bloom_pong,
+            sampler_linear,
+            sampler_clamp,
+            _noise_texture: noise_texture,
+            noise_view,
+            uniform_buffer,
+            uniform_bind_group,
+            ssao_layout,
+            ssao_pipeline,
+            bloom_prefilter_layout,
+            bloom_prefilter_pipeline,
+            bloom_blur_layout,
+            bloom_blur_horizontal,
+            bloom_blur_vertical,
+            composite_layout,
+            composite_pipeline,
+            size,
+            last_proj: Mat4::IDENTITY,
+            last_near: 0.01,
+            last_far: 1000.0,
+        };
+
+        let initial_uniform = PostProcessUniform::new(
+            post.last_proj,
+            post.last_proj.inverse(),
+            post.size.width as f32,
+            post.size.height as f32,
+            post.last_near,
+            post.last_far,
+        );
+        queue.write_buffer(
+            &post.uniform_buffer,
+            0,
+            bytemuck::bytes_of(&initial_uniform),
+        );
+
+        post
+    }
+
+    pub fn resize(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        width: u32,
+        height: u32,
+        format: wgpu::TextureFormat,
+    ) {
+        if width == 0 || height == 0 {
+            return;
+        }
+        self.size = wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        };
+        self.scene = TextureBundle::color(device, &self.size, format, "SceneColor");
+        self.ssao = TextureBundle::ssao(device, &self.size);
+        self.bloom_ping = TextureBundle::bloom(device, &self.size, "BloomPing");
+        self.bloom_pong = TextureBundle::bloom(device, &self.size, "BloomPong");
+        self.upload_uniform(queue);
+    }
+
+    pub fn update_camera(&mut self, queue: &wgpu::Queue, proj: Mat4, near: f32, far: f32) {
+        self.last_proj = proj;
+        self.last_near = near;
+        self.last_far = far;
+        self.upload_uniform(queue);
+    }
+
+    pub fn scene_view(&self) -> &wgpu::TextureView {
+        &self.scene.view
+    }
+
+    pub fn ssao_texture(&self) -> &wgpu::TextureView {
+        &self.ssao.view
+    }
+
+    pub fn bloom_texture(&self) -> &wgpu::TextureView {
+        &self.bloom_ping.view
+    }
+
+    pub fn execute(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        device: &wgpu::Device,
+        depth_view: &wgpu::TextureView,
+        target: &wgpu::TextureView,
+    ) {
+        // SSAO
+        let ssao_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("SsaoBindGroup"),
+            layout: &self.ssao_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(depth_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::TextureView(&self.noise_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: wgpu::BindingResource::Sampler(&self.sampler_clamp),
+                },
+            ],
+        });
+
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("SsaoPass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &self.ssao.view,
+                    resolve_target: None,
+                    depth_slice: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::WHITE),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            pass.set_pipeline(&self.ssao_pipeline);
+            pass.set_bind_group(0, &self.uniform_bind_group, &[]);
+            pass.set_bind_group(1, &ssao_bind_group, &[]);
+            pass.draw(0..3, 0..1);
+        }
+
+        let bloom_prefilter_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("BloomPrefilterBindGroup"),
+            layout: &self.bloom_prefilter_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&self.scene.view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(&self.sampler_linear),
+                },
+            ],
+        });
+
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("BloomPrefilter"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &self.bloom_ping.view,
+                    resolve_target: None,
+                    depth_slice: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            pass.set_pipeline(&self.bloom_prefilter_pipeline);
+            pass.set_bind_group(0, &bloom_prefilter_bind_group, &[]);
+            pass.draw(0..3, 0..1);
+        }
+
+        let horizontal_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("BloomHorizontalBindGroup"),
+            layout: &self.bloom_blur_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&self.bloom_ping.view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(&self.sampler_linear),
+                },
+            ],
+        });
+
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("BloomBlurHorizontal"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &self.bloom_pong.view,
+                    resolve_target: None,
+                    depth_slice: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            pass.set_pipeline(&self.bloom_blur_horizontal);
+            pass.set_bind_group(0, &horizontal_bind_group, &[]);
+            pass.draw(0..3, 0..1);
+        }
+
+        let vertical_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("BloomVerticalBindGroup"),
+            layout: &self.bloom_blur_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&self.bloom_pong.view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(&self.sampler_linear),
+                },
+            ],
+        });
+
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("BloomBlurVertical"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &self.bloom_ping.view,
+                    resolve_target: None,
+                    depth_slice: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            pass.set_pipeline(&self.bloom_blur_vertical);
+            pass.set_bind_group(0, &vertical_bind_group, &[]);
+            pass.draw(0..3, 0..1);
+        }
+
+        let composite_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("CompositeBindGroup"),
+            layout: &self.composite_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&self.scene.view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::TextureView(&self.ssao.view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: wgpu::BindingResource::TextureView(&self.bloom_ping.view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: wgpu::BindingResource::Sampler(&self.sampler_linear),
+                },
+            ],
+        });
+
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("CompositePass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: target,
+                    resolve_target: None,
+                    depth_slice: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            pass.set_pipeline(&self.composite_pipeline);
+            pass.set_bind_group(0, &composite_bind_group, &[]);
+            pass.set_bind_group(1, &self.uniform_bind_group, &[]);
+            pass.draw(0..3, 0..1);
+        }
+    }
+}
+
+impl PostProcess {
+    fn upload_uniform(&self, queue: &wgpu::Queue) {
+        let proj_inv = self.last_proj.inverse();
+        let uniform = PostProcessUniform::new(
+            self.last_proj,
+            proj_inv,
+            self.size.width as f32,
+            self.size.height as f32,
+            self.last_near,
+            self.last_far,
+        );
+        queue.write_buffer(&self.uniform_buffer, 0, bytemuck::bytes_of(&uniform));
+    }
+
+    fn create_noise_texture(device: &wgpu::Device, queue: &wgpu::Queue) -> wgpu::Texture {
+        let data_bytes = bytemuck::cast_slice(&SSAO_NOISE_DATA);
+
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("SsaoNoiseTexture"),
+            size: wgpu::Extent3d {
+                width: NOISE_TEXTURE_SIZE,
+                height: NOISE_TEXTURE_SIZE,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba32Float,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
+        });
+
+        queue.write_texture(
+            wgpu::TexelCopyTextureInfo {
+                texture: &texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            data_bytes,
+            wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some((4 * std::mem::size_of::<f32>()) as u32 * NOISE_TEXTURE_SIZE),
+                rows_per_image: Some(NOISE_TEXTURE_SIZE),
+            },
+            wgpu::Extent3d {
+                width: NOISE_TEXTURE_SIZE,
+                height: NOISE_TEXTURE_SIZE,
+                depth_or_array_layers: 1,
+            },
+        );
+
+        texture
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+struct PostProcessUniform {
+    proj: [[f32; 4]; 4],
+    proj_inv: [[f32; 4]; 4],
+    resolution: [f32; 2],
+    radius_bias: [f32; 2],
+    intensity_power: [f32; 2],
+    noise_scale: [f32; 2],
+    near_far: [f32; 2],
+}
+
+impl PostProcessUniform {
+    fn new(proj: Mat4, proj_inv: Mat4, width: f32, height: f32, near: f32, far: f32) -> Self {
+        let radius = 0.5f32;
+        let bias = 0.025f32;
+        let intensity = 1.5f32;
+        let power = 1.1f32;
+        let noise_scale = [
+            width / NOISE_TEXTURE_SIZE as f32,
+            height / NOISE_TEXTURE_SIZE as f32,
+        ];
+        Self {
+            proj: proj.to_cols_array_2d(),
+            proj_inv: proj_inv.to_cols_array_2d(),
+            resolution: [width, height],
+            radius_bias: [radius, bias],
+            intensity_power: [intensity, power],
+            noise_scale,
+            near_far: [near, far],
+        }
+    }
+}
+
+#[derive(Clone)]
+struct TextureBundle {
+    _texture: wgpu::Texture,
+    view: wgpu::TextureView,
+    format: wgpu::TextureFormat,
+}
+
+impl TextureBundle {
+    fn color(
+        device: &wgpu::Device,
+        size: &wgpu::Extent3d,
+        format: wgpu::TextureFormat,
+        label: &str,
+    ) -> Self {
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some(label),
+            size: *size,
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        });
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        Self {
+            _texture: texture,
+            view,
+            format,
+        }
+    }
+
+    fn ssao(device: &wgpu::Device, size: &wgpu::Extent3d) -> Self {
+        let format = wgpu::TextureFormat::R8Unorm;
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("SsaoTexture"),
+            size: *size,
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        });
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        Self {
+            _texture: texture,
+            view,
+            format,
+        }
+    }
+
+    fn bloom(device: &wgpu::Device, size: &wgpu::Extent3d, label: &str) -> Self {
+        let format = wgpu::TextureFormat::Rgba16Float;
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some(label),
+            size: *size,
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        });
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        Self {
+            _texture: texture,
+            view,
+            format,
+        }
+    }
+}

--- a/src/shader/postprocess.wgsl
+++ b/src/shader/postprocess.wgsl
@@ -1,0 +1,219 @@
+struct VertexOutput {
+    @builtin(position) position : vec4<f32>,
+    @location(0) uv : vec2<f32>,
+};
+
+@vertex
+fn vs_fullscreen(@builtin(vertex_index) vertex_index : u32) -> VertexOutput {
+    var positions = array<vec2<f32>, 3>(
+        vec2<f32>(-1.0, -3.0),
+        vec2<f32>(-1.0, 1.0),
+        vec2<f32>(3.0, 1.0)
+    );
+    let pos = positions[vertex_index];
+    var out : VertexOutput;
+    out.position = vec4<f32>(pos, 0.0, 1.0);
+    out.uv = 0.5 * (pos + vec2<f32>(1.0, 1.0));
+    return out;
+}
+
+struct PostUniform {
+    proj : mat4x4<f32>,
+    proj_inv : mat4x4<f32>,
+    resolution : vec2<f32>,
+    radius_bias : vec2<f32>,
+    intensity_power : vec2<f32>,
+    noise_scale : vec2<f32>,
+    near_far : vec2<f32>,
+};
+
+@group(0) @binding(0)
+var<uniform> post_uniform : PostUniform;
+
+@group(1) @binding(0)
+var depth_texture : texture_depth_2d;
+@group(1) @binding(1)
+var noise_texture : texture_2d<f32>;
+@group(1) @binding(2)
+var clamp_sampler : sampler;
+
+fn reconstruct_view_position(uv : vec2<f32>, depth : f32) -> vec3<f32> {
+    let clip = vec4<f32>(uv * 2.0 - 1.0, depth * 2.0 - 1.0, 1.0);
+    let view = post_uniform.proj_inv * clip;
+    return view.xyz / view.w;
+}
+
+fn fetch_depth(uv : vec2<f32>) -> f32 {
+    if (uv.x <= 0.0 || uv.x >= 1.0 || uv.y <= 0.0 || uv.y >= 1.0) {
+        return 1.0;
+    }
+    let tex_size = vec2<f32>(textureDimensions(depth_texture, 0));
+    let coord = vec2<i32>(uv * tex_size);
+    return textureLoad(depth_texture, coord, 0);
+}
+
+fn view_normal(uv : vec2<f32>, view_pos : vec3<f32>) -> vec3<f32> {
+    let texel = 1.0 / post_uniform.resolution;
+    let depth_right = fetch_depth(uv + vec2<f32>(texel.x, 0.0));
+    let depth_up = fetch_depth(uv + vec2<f32>(0.0, texel.y));
+    let pos_right = reconstruct_view_position(uv + vec2<f32>(texel.x, 0.0), depth_right);
+    let pos_up = reconstruct_view_position(uv + vec2<f32>(0.0, texel.y), depth_up);
+    let tangent = pos_right - view_pos;
+    let bitangent = pos_up - view_pos;
+    return normalize(cross(tangent, bitangent));
+}
+
+fn ssao_kernel() -> array<vec3<f32>, 32> {
+    return array<vec3<f32>, 32>(
+        vec3<f32>(0.5381, 0.1856, 0.4319),
+        vec3<f32>(0.1379, 0.2486, 0.4430),
+        vec3<f32>(0.3371, 0.5679, 0.0057),
+        vec3<f32>(-0.6999, -0.0451, -0.0019),
+        vec3<f32>(0.0689, -0.1598, 0.8547),
+        vec3<f32>(0.0560, 0.0069, -0.1843),
+        vec3<f32>(-0.0146, 0.1402, 0.0762),
+        vec3<f32>(0.0100, -0.1924, -0.0344),
+        vec3<f32>(-0.3577, -0.5301, -0.4358),
+        vec3<f32>(-0.3169, 0.1063, 0.0158),
+        vec3<f32>(0.0103, -0.5869, 0.0046),
+        vec3<f32>(-0.0897, -0.4940, 0.3287),
+        vec3<f32>(0.7119, -0.0154, -0.0918),
+        vec3<f32>(-0.0533, 0.0596, -0.5411),
+        vec3<f32>(0.0352, -0.0631, 0.5460),
+        vec3<f32>(-0.4776, 0.2847, -0.0271),
+        vec3<f32>(0.3333, -0.3596, 0.3830),
+        vec3<f32>(-0.2941, 0.2513, 0.1042),
+        vec3<f32>(0.2624, 0.5570, -0.0846),
+        vec3<f32>(0.1248, 0.1221, -0.5559),
+        vec3<f32>(-0.6291, 0.1545, 0.2803),
+        vec3<f32>(0.3933, 0.5746, -0.0978),
+        vec3<f32>(-0.4925, 0.2801, -0.2511),
+        vec3<f32>(-0.1279, -0.4738, -0.0977),
+        vec3<f32>(-0.2346, 0.0931, 0.3024),
+        vec3<f32>(0.0035, -0.1466, -0.3281),
+        vec3<f32>(0.1647, 0.2177, 0.2720),
+        vec3<f32>(0.4625, -0.1217, -0.4370),
+        vec3<f32>(0.0702, 0.4898, -0.1250),
+        vec3<f32>(-0.0441, -0.3091, 0.2510),
+        vec3<f32>(-0.3645, -0.1065, 0.4305),
+        vec3<f32>(0.0207, -0.1306, -0.2221)
+    );
+}
+
+@fragment
+fn fs_ssao(in : VertexOutput) -> @location(0) vec4<f32> {
+    let depth = fetch_depth(in.uv);
+    if (depth >= 1.0) {
+        return vec4<f32>(1.0, 1.0, 1.0, 1.0);
+    }
+
+    let view_pos = reconstruct_view_position(in.uv, depth);
+    let normal = view_normal(in.uv, view_pos);
+    let noise = textureSample(noise_texture, clamp_sampler, in.uv * post_uniform.noise_scale);
+    let tangent = normalize(noise.xyz * 2.0 - vec3<f32>(1.0, 1.0, 1.0));
+    let bitangent = normalize(cross(normal, tangent));
+    let tbn = mat3x3<f32>(tangent, bitangent, normal);
+
+    var occlusion = 0.0;
+    let samples = ssao_kernel();
+    for (var i : u32 = 0u; i < 32u; i = i + 1u) {
+        var sample = tbn * samples[i];
+        sample = view_pos + sample * post_uniform.radius_bias.x;
+
+        let sample_clip = post_uniform.proj * vec4<f32>(sample, 1.0);
+        var offset = sample_clip.xyz / sample_clip.w;
+        offset = offset * 0.5 + vec3<f32>(0.5, 0.5, 0.5);
+        if (offset.z >= 1.0) {
+            continue;
+        }
+        let sample_depth = fetch_depth(offset.xy);
+        let range_check = smoothstep(0.0, 1.0, post_uniform.radius_bias.x / abs(view_pos.z - sample.z));
+        let bias = post_uniform.radius_bias.y;
+        if (sample_depth < offset.z - bias) {
+            occlusion = occlusion + range_check;
+        }
+    }
+    let ao = 1.0 - occlusion / 32.0;
+    let ao_pow = pow(ao, post_uniform.intensity_power.y);
+    let strength = clamp(post_uniform.intensity_power.x, 0.0, 5.0);
+    return vec4<f32>(mix(1.0, ao_pow, strength), 1.0, 1.0, 1.0);
+}
+
+// Bloom prefilter
+@group(0) @binding(0)
+var scene_texture : texture_2d<f32>;
+@group(0) @binding(1)
+var scene_sampler : sampler;
+
+@fragment
+fn fs_bloom_prefilter(in : VertexOutput) -> @location(0) vec4<f32> {
+    let color = textureSample(scene_texture, scene_sampler, in.uv);
+    let brightness = max(max(color.r, color.g), color.b);
+    let threshold = 1.0;
+    let soft = 0.8;
+    let intensity = clamp((brightness - threshold * soft) / max(0.0001, 1.0 - soft), 0.0, 1.0);
+    return vec4<f32>(color.rgb * intensity, 1.0);
+}
+
+// Bloom blur horizontal
+@group(0) @binding(0)
+var blur_texture : texture_2d<f32>;
+@group(0) @binding(1)
+var blur_sampler : sampler;
+
+fn gaussian_weight(x : f32) -> f32 {
+    let sigma = 4.0;
+    return exp(-(x * x) / (2.0 * sigma * sigma));
+}
+
+@fragment
+fn fs_bloom_blur_horizontal(in : VertexOutput) -> @location(0) vec4<f32> {
+    let tex_size = vec2<f32>(textureDimensions(blur_texture, 0));
+    let texel = vec2<f32>(1.0 / tex_size.x, 0.0);
+    var result = vec3<f32>(0.0);
+    var total = 0.0;
+    for (var i : i32 = -8; i <= 8; i = i + 1) {
+        let w = gaussian_weight(f32(i));
+        let color = textureSample(blur_texture, blur_sampler, in.uv + texel * f32(i)).rgb;
+        result = result + color * w;
+        total = total + w;
+    }
+    return vec4<f32>(result / total, 1.0);
+}
+
+@fragment
+fn fs_bloom_blur_vertical(in : VertexOutput) -> @location(0) vec4<f32> {
+    let tex_size = vec2<f32>(textureDimensions(blur_texture, 0));
+    let texel = vec2<f32>(0.0, 1.0 / tex_size.y);
+    var result = vec3<f32>(0.0);
+    var total = 0.0;
+    for (var i : i32 = -8; i <= 8; i = i + 1) {
+        let w = gaussian_weight(f32(i));
+        let color = textureSample(blur_texture, blur_sampler, in.uv + texel * f32(i)).rgb;
+        result = result + color * w;
+        total = total + w;
+    }
+    return vec4<f32>(result / total, 1.0);
+}
+
+@group(0) @binding(0)
+var composite_scene : texture_2d<f32>;
+@group(0) @binding(1)
+var composite_ssao : texture_2d<f32>;
+@group(0) @binding(2)
+var composite_bloom : texture_2d<f32>;
+@group(0) @binding(3)
+var composite_sampler : sampler;
+
+@group(1) @binding(0)
+var<uniform> composite_uniform : PostUniform;
+
+@fragment
+fn fs_composite(in : VertexOutput) -> @location(0) vec4<f32> {
+    let base = textureSample(composite_scene, composite_sampler, in.uv);
+    let ssao = textureSample(composite_ssao, composite_sampler, in.uv).r;
+    let bloom = textureSample(composite_bloom, composite_sampler, in.uv).rgb;
+    let shaded = base.rgb * ssao;
+    let result = shaded + bloom;
+    return vec4<f32>(result, base.a);
+}


### PR DESCRIPTION
## Summary
- add a postprocessing module with SSAO, bloom prefilter/blur, and composite passes
- render opaque/transparent passes into an offscreen target, run postprocessing, then draw overlays
- make the depth texture sampleable for SSAO and drop unused MSAA support

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68e42c8f7474832cb74cf28b02c4a563