### PR TITLE
Handle glTF alpha modes

### DIFF
--- a/src/scene/loader.rs
+++ b/src/scene/loader.rs
@@ -397,9 +397,12 @@ impl SceneLoader {
             }
 
             // Alpha mode
-            if gltf_mat.alpha_mode() == gltf::material::AlphaMode::Blend {
-                material = material.with_alpha();
-            }
+            material = match gltf_mat.alpha_mode() {
+                gltf::material::AlphaMode::Opaque => material,
+                gltf::material::AlphaMode::Mask | gltf::material::AlphaMode::Blend => {
+                    material.with_alpha()
+                }
+            };
 
             log::debug!(
                 "  Material '{}': metallic={:.2}, roughness={:.2}",


### PR DESCRIPTION
## Summary
- treat glTF materials using either Blend or Mask alpha modes as transparent during import

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e4ba08d680832c81ff9d8ad17fe986