### PR TITLE
Add scene camera management

### DIFF
--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -1,6 +1,7 @@
+use glam::Vec3;
 use log::info;
 use wgpu_cube::app::{AppBuilder, StartupContext};
-use wgpu_cube::scene::SceneLoader;
+use wgpu_cube::scene::{Camera, SceneLoader};
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
@@ -26,6 +27,12 @@ fn load_scene(ctx: &mut StartupContext<'_>) {
     match SceneLoader::load_gltf(CHESS_GLTF_PATH, scene, renderer, SCENE_SCALE) {
         Ok(_) => {
             scene.add_default_lighting();
+            scene.set_camera(Camera {
+                eye: Vec3::new(1.5, 2.5, 3.0),
+                target: Vec3::ZERO,
+                up: Vec3::Y,
+                ..Camera::default()
+            });
             info!("glTF loaded: {} entities", scene.world.len());
         }
         Err(err) => {

--- a/examples/chess.rs
+++ b/examples/chess.rs
@@ -43,9 +43,10 @@ fn orbit_camera(
 ) -> Box<dyn for<'a> FnMut(&mut UpdateContext<'a>) + 'static> {
     Box::new(move |ctx: &mut UpdateContext<'_>| {
         let t = ctx.scene.time() as f32 * 0.25;
-        ctx.camera.eye = Vec3::new(t.cos() * radius, height, t.sin() * radius);
-        ctx.camera.target = Vec3::ZERO;
-        ctx.camera.up = Vec3::Y;
+        let camera = ctx.scene.camera_mut();
+        camera.eye = Vec3::new(t.cos() * radius, height, t.sin() * radius);
+        camera.target = Vec3::ZERO;
+        camera.up = Vec3::Y;
     })
 }
 

--- a/examples/grid.rs
+++ b/examples/grid.rs
@@ -66,9 +66,10 @@ fn orbit_camera(
 ) -> Box<dyn for<'a> FnMut(&mut UpdateContext<'a>) + 'static> {
     Box::new(move |ctx: &mut UpdateContext<'_>| {
         let t = ctx.scene.time() as f32 * 0.25;
-        ctx.camera.eye = Vec3::new(t.cos() * radius, height, t.sin() * radius);
-        ctx.camera.target = Vec3::ZERO;
-        ctx.camera.up = Vec3::Y;
+        let camera = ctx.scene.camera_mut();
+        camera.eye = Vec3::new(t.cos() * radius, height, t.sin() * radius);
+        camera.target = Vec3::ZERO;
+        camera.up = Vec3::Y;
     })
 }
 

--- a/examples/hierarchy.rs
+++ b/examples/hierarchy.rs
@@ -216,9 +216,10 @@ fn orbit_camera(
 ) -> Box<dyn for<'a> FnMut(&mut UpdateContext<'a>) + 'static> {
     Box::new(move |ctx: &mut UpdateContext<'_>| {
         let t = ctx.scene.time() as f32 * 0.25;
-        ctx.camera.eye = Vec3::new(t.cos() * radius, height, t.sin() * radius);
-        ctx.camera.target = Vec3::ZERO;
-        ctx.camera.up = Vec3::Y;
+        let camera = ctx.scene.camera_mut();
+        camera.eye = Vec3::new(t.cos() * radius, height, t.sin() * radius);
+        camera.target = Vec3::ZERO;
+        camera.up = Vec3::Y;
     })
 }
 

--- a/examples/pbr.rs
+++ b/examples/pbr.rs
@@ -121,9 +121,10 @@ fn orbit_camera(
 ) -> Box<dyn for<'a> FnMut(&mut UpdateContext<'a>) + 'static> {
     Box::new(move |ctx: &mut UpdateContext<'_>| {
         let t = ctx.scene.time() as f32 * 0.25;
-        ctx.camera.eye = Vec3::new(t.cos() * radius, height, t.sin() * radius);
-        ctx.camera.target = Vec3::ZERO;
-        ctx.camera.up = Vec3::Y;
+        let camera = ctx.scene.camera_mut();
+        camera.eye = Vec3::new(t.cos() * radius, height, t.sin() * radius);
+        camera.target = Vec3::ZERO;
+        camera.up = Vec3::Y;
     })
 }
 

--- a/examples/shadow.rs
+++ b/examples/shadow.rs
@@ -118,9 +118,10 @@ fn orbit_camera(
 ) -> Box<dyn for<'a> FnMut(&mut UpdateContext<'a>) + 'static> {
     Box::new(move |ctx: &mut UpdateContext<'_>| {
         let t = ctx.scene.time() as f32 * 0.25;
-        ctx.camera.eye = Vec3::new(t.cos() * radius, height, t.sin() * radius);
-        ctx.camera.target = Vec3::ZERO;
-        ctx.camera.up = Vec3::Y;
+        let camera = ctx.scene.camera_mut();
+        camera.eye = Vec3::new(t.cos() * radius, height, t.sin() * radius);
+        camera.target = Vec3::ZERO;
+        camera.up = Vec3::Y;
     })
 }
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -83,9 +83,10 @@ fn orbit_camera(
 ) -> Box<dyn for<'a> FnMut(&mut UpdateContext<'a>) + 'static> {
     Box::new(move |ctx: &mut UpdateContext<'_>| {
         let t = ctx.scene.time() as f32 * 0.25;
-        ctx.camera.eye = Vec3::new(t.cos() * radius, height, t.sin() * radius);
-        ctx.camera.target = Vec3::ZERO;
-        ctx.camera.up = Vec3::Y;
+        let camera = ctx.scene.camera_mut();
+        camera.eye = Vec3::new(t.cos() * radius, height, t.sin() * radius);
+        camera.target = Vec3::ZERO;
+        camera.up = Vec3::Y;
     })
 }
 

--- a/examples/sponza.rs
+++ b/examples/sponza.rs
@@ -46,9 +46,10 @@ fn orbit_camera(
 ) -> Box<dyn for<'a> FnMut(&mut UpdateContext<'a>) + 'static> {
     Box::new(move |ctx: &mut UpdateContext<'_>| {
         let t = ctx.scene.time() as f32 * 0.25;
-        ctx.camera.eye = Vec3::new(t.cos() * radius, height, t.sin() * radius);
-        ctx.camera.target = Vec3::ZERO;
-        ctx.camera.up = Vec3::Y;
+        let camera = ctx.scene.camera_mut();
+        camera.eye = Vec3::new(t.cos() * radius, height, t.sin() * radius);
+        camera.target = Vec3::ZERO;
+        camera.up = Vec3::Y;
     })
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -23,7 +23,7 @@ type WindowHandle = Window;
 #[cfg(target_arch = "wasm32")]
 type PendingRenderer = Rc<RefCell<Option<Renderer>>>;
 
-use crate::scene::{Camera, Children, MeshComponent, Name, Parent, Scene, TransformComponent};
+use crate::scene::{Children, MeshComponent, Name, Parent, Scene, TransformComponent};
 use crate::time::Instant;
 
 pub struct StartupContext<'a> {
@@ -33,7 +33,6 @@ pub struct StartupContext<'a> {
 
 pub struct UpdateContext<'a> {
     pub scene: &'a mut Scene,
-    pub camera: &'a mut Camera,
     pub dt: f64,
 }
 
@@ -119,7 +118,6 @@ impl AppBuilder {
             window_id: None,
             scene: Scene::new(),
             batcher: RenderBatcher::new(),
-            camera: Camera::default(),
             startup_systems: self.startup_systems,
             update_systems: self.update_systems,
             auto_init_default_textures: self.auto_init_default_textures,
@@ -140,7 +138,6 @@ pub struct App {
     window_id: Option<WindowId>,
     scene: Scene,
     batcher: RenderBatcher,
-    camera: Camera,
     startup_systems: Vec<StartupSystem>,
     update_systems: Vec<UpdateSystem>,
     auto_init_default_textures: bool,
@@ -313,7 +310,6 @@ impl App {
         for system in &mut self.update_systems {
             let mut ctx = UpdateContext {
                 scene: &mut self.scene,
-                camera: &mut self.camera,
                 dt,
             };
             (system)(&mut ctx);
@@ -461,7 +457,7 @@ impl ApplicationHandler for App {
                 if !should_skip {
                     if let Some(renderer) = self.renderer.as_mut() {
                         let aspect = renderer.aspect_ratio();
-                        renderer.set_camera(&self.camera, aspect);
+                        renderer.set_camera(self.scene.camera(), aspect);
                         self.scene.render(renderer, &mut self.batcher);
                     }
                 }

--- a/src/scene/animation.rs
+++ b/src/scene/animation.rs
@@ -310,7 +310,11 @@ mod tests {
 
         let half = sampler.sample_quat(0.5).unwrap();
         let rotated_half = (half * Vec3::Z).normalize();
-        assert!(rotated_half.z.abs() < 1e-4, "unexpected slerp result: {:?}", half);
+        assert!(
+            rotated_half.z.abs() < 1e-4,
+            "unexpected slerp result: {:?}",
+            half
+        );
         assert!(
             (rotated_half.x.abs() - 1.0).abs() < 1e-4,
             "unexpected slerp result: {:?}",
@@ -347,10 +351,7 @@ mod tests {
         };
         let color_sampler = AnimationSampler {
             times: vec![0.0, 1.0],
-            output: AnimationOutput::Vec4(vec![
-                vec4(0.2, 0.2, 0.2, 1.0),
-                vec4(0.8, 0.4, 0.6, 1.0),
-            ]),
+            output: AnimationOutput::Vec4(vec![vec4(0.2, 0.2, 0.2, 1.0), vec4(0.8, 0.4, 0.6, 1.0)]),
             interpolation: AnimationInterpolation::Linear,
         };
 
@@ -376,10 +377,7 @@ mod tests {
 
         let transform = transform_updates.get(&entity).expect("missing transform");
         assert!(transform.rotation.is_none());
-        assert_eq!(
-            transform.translation.unwrap(),
-            vec3(1.0, 1.0, 1.0)
-        );
+        assert_eq!(transform.translation.unwrap(), vec3(1.0, 1.0, 1.0));
 
         let material = material_updates
             .get(&3)

--- a/src/scene/scene.rs
+++ b/src/scene/scene.rs
@@ -8,7 +8,7 @@ use crate::renderer::{
     DirectionalShadowData, LightsData, PointShadowData, RenderBatcher, RenderObject, Renderer,
     SpotShadowData,
 };
-use crate::scene::Transform;
+use crate::scene::{Camera, Transform};
 use crate::time::Instant;
 use glam::{Mat3, Mat4, Quat, Vec3};
 use hecs::World;
@@ -21,6 +21,7 @@ pub struct Scene {
     last_frame: Option<Instant>,
     animations: Vec<AnimationClip>,
     animation_states: Vec<AnimationState>,
+    camera: Camera,
 }
 
 impl Scene {
@@ -32,6 +33,7 @@ impl Scene {
             last_frame: None, // Start as None - will be initialized later
             animations: Vec::new(),
             animation_states: Vec::new(),
+            camera: Camera::default(),
         }
     }
 
@@ -63,6 +65,18 @@ impl Scene {
 
     pub fn animation_states_mut(&mut self) -> &mut Vec<AnimationState> {
         &mut self.animation_states
+    }
+
+    pub fn camera(&self) -> &Camera {
+        &self.camera
+    }
+
+    pub fn camera_mut(&mut self) -> &mut Camera {
+        &mut self.camera
+    }
+
+    pub fn set_camera(&mut self, camera: Camera) {
+        self.camera = camera;
     }
 
     pub fn add_animation_clip(&mut self, clip: AnimationClip) -> usize {


### PR DESCRIPTION
## Summary
- store the active camera on the scene and expose getters/setters for systems to use
- have the app drive the renderer from the scene camera and update orbit systems to mutate it through the scene
- initialize the animation example camera to look at the scene from a slightly elevated angle

## Testing
- cargo fmt
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68e4ed96e34c832cba097356d7dbf2c4