### PR TITLE
Fix Game of Life shader textureLoad invocation

### DIFF
--- a/examples/shaders/game_of_life.wgsl
+++ b/examples/shaders/game_of_life.wgsl
@@ -20,7 +20,7 @@ fn load_cell(position : vec2<i32>, dims : vec2<i32>) -> f32 {
         wrap_coord(position.x, dims.x),
         wrap_coord(position.y, dims.y),
     );
-    return textureLoad(state_src, wrapped, 0).r;
+    return textureLoad(state_src, wrapped).r;
 }
 
 @compute @workgroup_size(WORKGROUP_SIZE_X, WORKGROUP_SIZE_Y)


### PR DESCRIPTION
## Summary
- remove the unused LOD argument from the Game of Life compute shader's textureLoad call so it conforms to the WGSL storage texture signature

## Testing
- cargo check --example game_of_life

------
https://chatgpt.com/codex/tasks/task_e_68e4fb2a1160832c9f76f5ac4c869bf7