### PR TITLE
Fix storage texture bindings in Game of Life shader

### DIFF
--- a/examples/shaders/game_of_life.wgsl
+++ b/examples/shaders/game_of_life.wgsl
@@ -2,10 +2,10 @@ const WORKGROUP_SIZE_X : u32 = 8u;
 const WORKGROUP_SIZE_Y : u32 = 8u;
 
 @group(0) @binding(0)
-var<storage, read> state_src : texture_storage_2d<rgba8unorm, read>;
+var state_src : texture_storage_2d<rgba8unorm, read>;
 
 @group(0) @binding(1)
-var<storage, write> state_dst : texture_storage_2d<rgba8unorm, write>;
+var state_dst : texture_storage_2d<rgba8unorm, write>;
 
 fn wrap_coord(value : i32, max_value : i32) -> i32 {
     var result = value % max_value;


### PR DESCRIPTION
## Summary
- update the Game of Life compute shader to use texture storage bindings without the storage address space qualifier

## Testing
- cargo check --example game_of_life

------
https://chatgpt.com/codex/tasks/task_e_68e4fc4b4054832c93f00c10a4dbefaa