### PR TITLE
Fix example logging configuration

### DIFF
--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -58,7 +58,6 @@ fn load_scene(ctx: &mut StartupContext<'_>) {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
-    env_logger::init();
     if let Err(err) = wgpu_cube::run(build_app()) {
         eprintln!("Application error: {err}");
     }

--- a/examples/animation_material.rs
+++ b/examples/animation_material.rs
@@ -43,7 +43,6 @@ fn load_scene(ctx: &mut StartupContext<'_>) {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
-    env_logger::init();
     if let Err(err) = wgpu_cube::run(build_app()) {
         eprintln!("Application error: {err}");
     }

--- a/examples/chess.rs
+++ b/examples/chess.rs
@@ -52,7 +52,6 @@ fn orbit_camera(
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
-    env_logger::init();
     if let Err(err) = wgpu_cube::run(build_app()) {
         eprintln!("Application error: {err}");
     }

--- a/examples/game_of_life.rs
+++ b/examples/game_of_life.rs
@@ -490,7 +490,6 @@ fn generate_initial_pattern(buffer: &mut [u8], width: u32, height: u32) {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
-    env_logger::init();
     if let Err(err) = wgpu_cube::run(build_app()) {
         eprintln!("Application error: {err}");
     }

--- a/examples/grid.rs
+++ b/examples/grid.rs
@@ -75,7 +75,6 @@ fn orbit_camera(
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
-    env_logger::init();
     if let Err(err) = wgpu_cube::run(build_app()) {
         eprintln!("Application error: {err}");
     }

--- a/examples/hierarchy.rs
+++ b/examples/hierarchy.rs
@@ -225,7 +225,6 @@ fn orbit_camera(
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
-    env_logger::init();
     if let Err(err) = wgpu_cube::run(build_app()) {
         eprintln!("Application error: {err}");
     }

--- a/examples/morph.rs
+++ b/examples/morph.rs
@@ -43,7 +43,6 @@ fn load_scene(ctx: &mut StartupContext<'_>) {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
-    env_logger::init();
     if let Err(err) = wgpu_cube::run(build_app()) {
         eprintln!("Application error: {err}");
     }

--- a/examples/pbr.rs
+++ b/examples/pbr.rs
@@ -130,7 +130,6 @@ fn orbit_camera(
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
-    env_logger::init();
     if let Err(err) = wgpu_cube::run(build_app()) {
         eprintln!("Application error: {err}");
     }

--- a/examples/shadow.rs
+++ b/examples/shadow.rs
@@ -127,7 +127,6 @@ fn orbit_camera(
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
-    env_logger::init();
     if let Err(err) = wgpu_cube::run(build_app()) {
         eprintln!("Application error: {err}");
     }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -92,7 +92,6 @@ fn orbit_camera(
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
-    env_logger::init();
     if let Err(err) = wgpu_cube::run(build_app()) {
         eprintln!("Application error: {err}");
     }

--- a/examples/sponza.rs
+++ b/examples/sponza.rs
@@ -55,7 +55,6 @@ fn orbit_camera(
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
-    env_logger::init();
     if let Err(err) = wgpu_cube::run(build_app()) {
         eprintln!("Application error: {err}");
     }


### PR DESCRIPTION
## Summary
- rely on the crate-provided logging initialization by removing duplicate logger setup from the native example binaries

## Testing
- cargo check --examples

------
https://chatgpt.com/codex/tasks/task_e_68e561ee9abc832ca01bc76729bc55ef