### PR TITLE
Add orthographic billboard rendering pass

### DIFF
--- a/src/renderer/batch.rs
+++ b/src/renderer/batch.rs
@@ -9,9 +9,10 @@ use std::collections::HashMap;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RenderPass {
-    Opaque,      // Normal opaque geometry
-    Transparent, // Alpha blended (needs sorting)
-    Overlay,     // Draw last, typically with depth disabled
+    Opaque,         // Normal opaque geometry
+    Transparent,    // Alpha blended (needs sorting)
+    Overlay,        // Draw last, typically with depth disabled
+    BillboardOrtho, // Screen-space billboards rendered with orthographic projection
 }
 
 /// A single renderable object instance
@@ -21,6 +22,7 @@ pub struct RenderObject {
     pub transform: Transform, // Changed from Mat4
     pub depth_state: DepthState,
     pub force_overlay: bool,
+    pub pass_override: Option<RenderPass>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -59,7 +61,9 @@ impl RenderBatcher {
     /// Add an object to be rendered
     pub fn add(&mut self, obj: RenderObject) {
         // Determine which pass this object belongs to
-        let pass = if obj.force_overlay {
+        let pass = if let Some(pass) = obj.pass_override {
+            pass
+        } else if obj.force_overlay {
             RenderPass::Overlay
         } else if obj.material.requires_separate_pass() {
             RenderPass::Transparent

--- a/src/scene/components.rs
+++ b/src/scene/components.rs
@@ -19,6 +19,21 @@ pub enum BillboardOrientation {
     FaceCameraYAxis,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BillboardProjection {
+    /// Use the scene camera's projection (default behaviour).
+    Perspective,
+    /// Render in a dedicated orthographic pass that treats the transform
+    /// translation as screen-space units.
+    Orthographic,
+}
+
+impl Default for BillboardProjection {
+    fn default() -> Self {
+        Self::Perspective
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub enum BillboardSpace {
     /// Use the transform's translation directly in world space.
@@ -39,6 +54,7 @@ pub struct Billboard {
     pub orientation: BillboardOrientation,
     pub space: BillboardSpace,
     pub lit: bool,
+    pub projection: BillboardProjection,
 }
 
 impl Billboard {
@@ -47,6 +63,7 @@ impl Billboard {
             orientation,
             space: BillboardSpace::World,
             lit: false,
+            projection: BillboardProjection::default(),
         }
     }
 
@@ -57,6 +74,11 @@ impl Billboard {
 
     pub fn with_lighting(mut self, enabled: bool) -> Self {
         self.lit = enabled;
+        self
+    }
+
+    pub fn with_projection(mut self, projection: BillboardProjection) -> Self {
+        self.projection = projection;
         self
     }
 }

--- a/src/scene/scene.rs
+++ b/src/scene/scene.rs
@@ -5,8 +5,8 @@ use super::animation::{
 use super::components::*;
 use crate::asset::Assets;
 use crate::renderer::{
-    DirectionalShadowData, LightsData, PointShadowData, RenderBatcher, RenderObject, Renderer,
-    SpotShadowData,
+    DirectionalShadowData, LightsData, PointShadowData, RenderBatcher, RenderObject, RenderPass,
+    Renderer, SpotShadowData,
 };
 use crate::scene::{Camera, Transform};
 use crate::time::Instant;
@@ -207,27 +207,38 @@ impl Scene {
                     };
 
                     let mut material_value = *material;
+                    let depth_state_val = depth_state.unwrap_or_default();
+                    let mut force_overlay = false;
+                    let mut pass_override = None;
 
                     if let Some(billboard_val) = billboard {
-                        transform = Self::apply_billboard_transform(
-                            transform,
-                            *billboard_val,
-                            camera_pos,
-                            camera_target,
-                            camera_up,
-                        );
+                        if !matches!(billboard_val.projection, BillboardProjection::Orthographic) {
+                            transform = Self::apply_billboard_transform(
+                                transform,
+                                *billboard_val,
+                                camera_pos,
+                                camera_target,
+                                camera_up,
+                            );
+                        }
 
                         if billboard_val.lit {
                             material_value = material_value.with_lit();
                         } else {
                             material_value = material_value.with_unlit();
                         }
-                    }
 
-                    let depth_state_val = depth_state.unwrap_or_default();
-                    let force_overlay = billboard.is_some()
-                        && !depth_state_val.depth_test
-                        && !depth_state_val.depth_write;
+                        match billboard_val.projection {
+                            BillboardProjection::Orthographic => {
+                                pass_override = Some(RenderPass::BillboardOrtho);
+                            }
+                            BillboardProjection::Perspective => {
+                                if !depth_state_val.depth_test && !depth_state_val.depth_write {
+                                    force_overlay = true;
+                                }
+                            }
+                        }
+                    }
 
                     Some(RenderObject {
                         mesh: *mesh, // FIXED: just dereference, it's already Handle<Mesh>
@@ -235,6 +246,7 @@ impl Scene {
                         transform,
                         depth_state: depth_state_val,
                         force_overlay,
+                        pass_override,
                     })
                 },
             )
@@ -1096,14 +1108,10 @@ mod tests {
             view_up = view_up.normalize();
         }
 
-        let expected_translation = camera_pos
-            + view_right * offset.x
-            + view_up * offset.y
-            + view_forward * offset.z;
+        let expected_translation =
+            camera_pos + view_right * offset.x + view_up * offset.y + view_forward * offset.z;
 
-        assert!(result
-            .translation
-            .abs_diff_eq(expected_translation, 1e-5));
+        assert!(result.translation.abs_diff_eq(expected_translation, 1e-5));
         assert!((result.rotation * Vec3::X).abs_diff_eq(view_right, 1e-5));
         assert!((result.rotation * Vec3::Y).abs_diff_eq(view_up, 1e-5));
         assert!((result.rotation * Vec3::Z).abs_diff_eq(-view_forward, 1e-5));
@@ -1111,11 +1119,8 @@ mod tests {
 
     #[test]
     fn world_space_billboard_faces_camera_position() {
-        let transform = Transform::from_trs(
-            Vec3::new(-2.0, 1.0, -5.0),
-            Quat::IDENTITY,
-            Vec3::splat(1.5),
-        );
+        let transform =
+            Transform::from_trs(Vec3::new(-2.0, 1.0, -5.0), Quat::IDENTITY, Vec3::splat(1.5));
         let billboard = Billboard::new(BillboardOrientation::FaceCamera);
         let camera_pos = Vec3::new(4.0, 3.0, 2.0);
         let camera_target = Vec3::new(0.0, 0.0, 0.0);


### PR DESCRIPTION
## Summary
- add an orthographic billboard projection option controlled by a new component flag
- update the renderer to support a dedicated orthographic billboard pass with configurable screen size
- adjust the shadow example to demonstrate four corner billboards using the new pass

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68e60ac325c8832c91c5a1cc0d9e2f1d