### PR TITLE
fix(gpu_particles): remove stray comments and consolidate Particle import in pools.rs

### DIFF
--- a/src/gpu_particles/pools.rs
+++ b/src/gpu_particles/pools.rs
@@ -5,6 +5,8 @@ use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 use std::rc::Rc;
 
+use crate::gpu_particles::particle::Particle;
+
 /// RAII guard that returns pooled object on drop
 pub struct PooledVec<T> {
     vec: Option<Vec<T>>,
@@ -76,7 +78,7 @@ impl<T> VecPool<T> {
             .pool
             .pop()
             .unwrap_or_else(|| Vec::with_capacity(self.default_capacity));
-        vec.clear(); // ← ADD THIS LINE
+        vec.clear();
         vec
     }
 
@@ -113,10 +115,6 @@ mod tests {
         assert!(vec2.capacity() >= 10);
     }
 }
-
-// Add to end of src/gpu_particles/pools.rs
-
-use crate::gpu_particles::particle::Particle;
 
 thread_local! {
     static PARTICLE_VEC_POOL: RefCell<VecPool<Particle>> = RefCell::new(


### PR DESCRIPTION
### Motivation
- Clean up stray comment markers and duplicated import lines in `src/gpu_particles/pools.rs` to improve readability.
- Consolidate the `Particle` import into the primary import block to match project import style.
- Avoid potential unused-import warnings and keep the module tidy for future edits.

### Description
- Move `use crate::gpu_particles::particle::Particle;` into the top import block of `src/gpu_particles/pools.rs`.
- Remove the stray comment `// ← ADD THIS LINE` and the footer comment `// Add to end...` plus the duplicate `use` at the file end.
- Preserve the existing `vec.clear()` behavior in `VecPool::acquire` and leave thread-local pools and accessor functions unchanged.
- Keep imports ordered and formatted consistent with the surrounding code.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6957392f8f24832d8c26b046129c01d3)